### PR TITLE
chore(deps): raise node engines floor to 22.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "vue-tsc": "^3.2.8"
       },
       "engines": {
-        "node": ">=22.12.0 <23"
+        "node": ">=22.13.0 <23"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "vue-tsc": "^3.2.8"
   },
   "engines": {
-    "node": ">=22.12.0 <23"
+    "node": ">=22.13.0 <23"
   },
   "lint-staged": {
     "*.{js,vue}": "eslint --fix"

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -83,6 +83,8 @@ test('a11y: Lists route — after creating a list', async ({ page }) => {
   await page.goto('/new')
   await page.getByPlaceholder('List Name').fill('A11y Test')
   await page.getByRole('button', { name: 'Create' }).click()
+  await expect(page).toHaveURL(/\/[a-f0-9]{8}$/)
   await page.getByRole('link', { name: 'My Lists' }).click()
+  await expect(page).toHaveURL('/')
   await checkA11y(page)
 })


### PR DESCRIPTION
## Summary
- Bumps `engines.node` from `>=22.12.0 <23` to `>=22.13.0 <23` — prerequisite for eslint 10 which declares `engines.node = ^20.19 || ^22.13 || >=24`
- Fixes pre-existing color-contrast false positive in e2e a11y test by adding URL guard assertions before axe runs

## Test plan
- [x] `npm run lint` — pass
- [x] `npm run type-check` — pass
- [x] `npm run test:unit` — 23/23 pass
- [x] `npm run build` — pass (189 KB / 67 KB gz)
- [x] `npm run test:e2e` — 7/7 pass (including the previously failing a11y test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)