### PR TITLE
chore(deps): bump eslint-plugin-vue to 10.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-n": "^17.24.0",
         "eslint-plugin-promise": "^7.3.0",
-        "eslint-plugin-vue": "^10.9.0",
+        "eslint-plugin-vue": "^10.9.1",
         "eslint-plugin-vuejs-accessibility": "^2.5.0",
         "jsdom": "^29.1.1",
         "lint-staged": "^16.4.0",
@@ -7051,9 +7051,9 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.0.tgz",
-      "integrity": "sha512-EFNNzu4HqtTRb5DJINpyd+u3bDdzETWDMpCzG+UBHz1tpsnMDCeOcf61u4Wy/cbXnMymK+MT9bjH7KcG1fItSw==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.1.tgz",
+      "integrity": "sha512-cHB0Tf4Duvzwecwd/AqWzZvF/QszE13BhjVUpVXWCy9AeMR5GjkAjP3i85vqgLgOuTmkHR1OJ5oMeqLHtuw8zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7071,7 +7071,7 @@
         "@stylistic/eslint-plugin": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
         "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "vue-eslint-parser": "^10.0.0"
+        "vue-eslint-parser": "^10.3.0"
       },
       "peerDependenciesMeta": {
         "@stylistic/eslint-plugin": {
@@ -17472,9 +17472,9 @@
       }
     },
     "eslint-plugin-vue": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.0.tgz",
-      "integrity": "sha512-EFNNzu4HqtTRb5DJINpyd+u3bDdzETWDMpCzG+UBHz1tpsnMDCeOcf61u4Wy/cbXnMymK+MT9bjH7KcG1fItSw==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.1.tgz",
+      "integrity": "sha512-cHB0Tf4Duvzwecwd/AqWzZvF/QszE13BhjVUpVXWCy9AeMR5GjkAjP3i85vqgLgOuTmkHR1OJ5oMeqLHtuw8zg==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-n": "^17.24.0",
     "eslint-plugin-promise": "^7.3.0",
-    "eslint-plugin-vue": "^10.9.0",
+    "eslint-plugin-vue": "^10.9.1",
     "eslint-plugin-vuejs-accessibility": "^2.5.0",
     "jsdom": "^29.1.1",
     "lint-staged": "^16.4.0",

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -86,5 +86,7 @@ test('a11y: Lists route — after creating a list', async ({ page }) => {
   await expect(page).toHaveURL(/\/[a-f0-9]{8}$/)
   await page.getByRole('link', { name: 'My Lists' }).click()
   await expect(page).toHaveURL('/')
+  // Wait for the route transition to fully complete before running axe
+  await expect(page.getByRole('link', { name: /A11y Test/ })).toBeVisible()
   await checkA11y(page)
 })


### PR DESCRIPTION
## Summary
- Bumps `eslint-plugin-vue` from `^10.9.0` to `^10.9.1` (minor)
- Strengthens a11y e2e test: waits for list card visibility after navigation to ensure the 150ms fade-out transition completes before axe scans the DOM

## Test plan
- [x] `npm run lint` — pass
- [x] `npm run type-check` — pass
- [x] `npm run test:unit` — 23/23 pass
- [x] `npm run build` — pass
- [x] `npm run test:e2e` — 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)