### PR TITLE
chore(deps): bump postcss to 8.5.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "eslint-plugin-vuejs-accessibility": "^2.5.0",
         "jsdom": "^29.1.1",
         "lint-staged": "^16.4.0",
-        "postcss": "^8.5.13",
+        "postcss": "^8.5.14",
         "sass": "^1.99.0",
         "tailwindcss": "^4.2.4",
         "typescript": "^6.0.3",
@@ -10245,9 +10245,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -19136,9 +19136,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "requires": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-vuejs-accessibility": "^2.5.0",
     "jsdom": "^29.1.1",
     "lint-staged": "^16.4.0",
-    "postcss": "^8.5.13",
+    "postcss": "^8.5.14",
     "sass": "^1.99.0",
     "tailwindcss": "^4.2.4",
     "typescript": "^6.0.3",


### PR DESCRIPTION
## Summary
- Bumps `postcss` from `^8.5.13` to `^8.5.14` (minor)
- Verified no unresolved `@apply` literals in `dist/assets/` — Tailwind v4 + Vue SFC pipeline intact

## Test plan
- [x] `npm run lint` — pass
- [x] `npm run type-check` — pass
- [x] `npm run test:unit` — 23/23 pass
- [x] `npm run build` — pass, inspected CSS chunks for `@apply` leakage (none found)
- [x] `npm run test:e2e` — 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)