### PR TITLE
chore(deps): bump eslint-plugin-n to 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@vue/tsconfig": "^0.9.1",
         "eslint": "^9.39.4",
         "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-n": "^17.24.0",
+        "eslint-plugin-n": "^18.0.1",
         "eslint-plugin-promise": "^7.3.0",
         "eslint-plugin-vue": "^10.9.1",
         "eslint-plugin-vuejs-accessibility": "^2.5.0",
@@ -5162,6 +5162,59 @@
         "eslint-plugin-vue": "^9.28.0 || ^10.0.0"
       }
     },
+    "node_modules/@vue/eslint-config-standard/node_modules/eslint-plugin-n": {
+      "version": "17.24.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.24.0.tgz",
+      "integrity": "sha512-/gC7/KAYmfNnPNOb3eu8vw+TdVnV0zhdQwexsw6FLXbhzroVj20vRn2qL8lDWDGnAQ2J8DhdfvXxX9EoxvERvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.5.0",
+        "enhanced-resolve": "^5.17.1",
+        "eslint-plugin-es-x": "^7.8.0",
+        "get-tsconfig": "^4.8.1",
+        "globals": "^15.11.0",
+        "globrex": "^0.1.2",
+        "ignore": "^5.3.2",
+        "semver": "^7.6.3",
+        "ts-declaration-location": "^1.0.6"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.23.0"
+      }
+    },
+    "node_modules/@vue/eslint-config-standard/node_modules/eslint-plugin-n/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vue/eslint-config-standard/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@vue/language-core": {
       "version": "3.2.8",
       "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.8.tgz",
@@ -6952,9 +7005,9 @@
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "17.24.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.24.0.tgz",
-      "integrity": "sha512-/gC7/KAYmfNnPNOb3eu8vw+TdVnV0zhdQwexsw6FLXbhzroVj20vRn2qL8lDWDGnAQ2J8DhdfvXxX9EoxvERvw==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-18.0.1.tgz",
+      "integrity": "sha512-q3ARhk+eZRc7myR0KHx+R3/GJeOHF+Ir6PK95Pu2tEX8Sl/4BIpmmVLva2kPrjC2gCmn6WHlHm+3yeo6Rxhycw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6965,17 +7018,26 @@
         "globals": "^15.11.0",
         "globrex": "^0.1.2",
         "ignore": "^5.3.2",
-        "semver": "^7.6.3",
-        "ts-declaration-location": "^1.0.6"
+        "semver": "^7.6.3"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
-        "eslint": ">=8.23.0"
+        "eslint": ">=8.57.1",
+        "ts-declaration-location": "^1.0.6",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-declaration-location": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-n/node_modules/globals": {
@@ -15877,6 +15939,39 @@
         "eslint-plugin-n": "^17.16.2",
         "eslint-plugin-promise": "^7.2.1",
         "globals": "^16.0.0"
+      },
+      "dependencies": {
+        "eslint-plugin-n": {
+          "version": "17.24.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.24.0.tgz",
+          "integrity": "sha512-/gC7/KAYmfNnPNOb3eu8vw+TdVnV0zhdQwexsw6FLXbhzroVj20vRn2qL8lDWDGnAQ2J8DhdfvXxX9EoxvERvw==",
+          "dev": true,
+          "requires": {
+            "@eslint-community/eslint-utils": "^4.5.0",
+            "enhanced-resolve": "^5.17.1",
+            "eslint-plugin-es-x": "^7.8.0",
+            "get-tsconfig": "^4.8.1",
+            "globals": "^15.11.0",
+            "globrex": "^0.1.2",
+            "ignore": "^5.3.2",
+            "semver": "^7.6.3",
+            "ts-declaration-location": "^1.0.6"
+          },
+          "dependencies": {
+            "globals": {
+              "version": "15.15.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+              "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+              "dev": true
+            }
+          }
+        },
+        "semver": {
+          "version": "7.7.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+          "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+          "dev": true
+        }
       }
     },
     "@vue/language-core": {
@@ -17228,9 +17323,9 @@
       }
     },
     "eslint-plugin-n": {
-      "version": "17.24.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.24.0.tgz",
-      "integrity": "sha512-/gC7/KAYmfNnPNOb3eu8vw+TdVnV0zhdQwexsw6FLXbhzroVj20vRn2qL8lDWDGnAQ2J8DhdfvXxX9EoxvERvw==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-18.0.1.tgz",
+      "integrity": "sha512-q3ARhk+eZRc7myR0KHx+R3/GJeOHF+Ir6PK95Pu2tEX8Sl/4BIpmmVLva2kPrjC2gCmn6WHlHm+3yeo6Rxhycw==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.5.0",
@@ -17240,8 +17335,7 @@
         "globals": "^15.11.0",
         "globrex": "^0.1.2",
         "ignore": "^5.3.2",
-        "semver": "^7.6.3",
-        "ts-declaration-location": "^1.0.6"
+        "semver": "^7.6.3"
       },
       "dependencies": {
         "globals": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@vue/tsconfig": "^0.9.1",
     "eslint": "^9.39.4",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-n": "^17.24.0",
+    "eslint-plugin-n": "^18.0.1",
     "eslint-plugin-promise": "^7.3.0",
     "eslint-plugin-vue": "^10.9.1",
     "eslint-plugin-vuejs-accessibility": "^2.5.0",


### PR DESCRIPTION
## Summary
- Bumps `eslint-plugin-n` from `^17.24.0` to `^18.0.1` (major, isolated before eslint 10)
- Peer requires `eslint >=8.57.1` — satisfied by current eslint 9.x; no coordinated bump needed
- No new rule violations from plugin-n 18 defaults

## Test plan
- [x] `npm install` — peer-dep warnings checked (none for plugin-n)
- [x] `npm run lint` — pass, no new violations
- [x] `npm run type-check` — pass
- [x] `npm run test:unit` — 23/23 pass
- [x] `npm run build` — pass
- [x] `npm run test:e2e` — 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)