### PR TITLE
chore(deps): bump vue to 3.5.34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "pinia": "^3.0.4",
-        "vue": "^3.5.33",
+        "vue": "^3.5.34",
         "vue-router": "^5.0.6"
       },
       "devDependencies": {
@@ -23,7 +23,7 @@
         "@tailwindcss/postcss": "^4.2.4",
         "@vitejs/plugin-vue": "^6.0.6",
         "@vitest/coverage-v8": "^4.1.5",
-        "@vue/compiler-sfc": "^3.5.33",
+        "@vue/compiler-sfc": "^3.5.34",
         "@vue/eslint-config-standard": "^9.0.1",
         "@vue/test-utils": "^2.4.10",
         "@vue/tsconfig": "^0.9.1",
@@ -4847,13 +4847,13 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
-      "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
+      "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.2",
-        "@vue/shared": "3.5.33",
+        "@babel/parser": "^7.29.3",
+        "@vue/shared": "3.5.34",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
@@ -4872,40 +4872,40 @@
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
-      "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
+      "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-core": "3.5.34",
+        "@vue/shared": "3.5.34"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
-      "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
+      "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.2",
-        "@vue/compiler-core": "3.5.33",
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/compiler-ssr": "3.5.33",
-        "@vue/shared": "3.5.33",
+        "@babel/parser": "^7.29.3",
+        "@vue/compiler-core": "3.5.34",
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.10",
+        "postcss": "^8.5.14",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
-      "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
+      "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/shared": "3.5.34"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -5054,53 +5054,53 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
-      "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
+      "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.33"
+        "@vue/shared": "3.5.34"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
-      "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
+      "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/reactivity": "3.5.34",
+        "@vue/shared": "3.5.34"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
-      "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
+      "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.33",
-        "@vue/runtime-core": "3.5.33",
-        "@vue/shared": "3.5.33",
+        "@vue/reactivity": "3.5.34",
+        "@vue/runtime-core": "3.5.34",
+        "@vue/shared": "3.5.34",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
-      "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
+      "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34"
       },
       "peerDependencies": {
-        "vue": "3.5.33"
+        "vue": "3.5.34"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
-      "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
+      "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
       "license": "MIT"
     },
     "node_modules/@vue/test-utils": {
@@ -11957,16 +11957,16 @@
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
-      "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
+      "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/compiler-sfc": "3.5.33",
-        "@vue/runtime-dom": "3.5.33",
-        "@vue/server-renderer": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-sfc": "3.5.34",
+        "@vue/runtime-dom": "3.5.34",
+        "@vue/server-renderer": "3.5.34",
+        "@vue/shared": "3.5.34"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -15432,12 +15432,12 @@
       }
     },
     "@vue/compiler-core": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
-      "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
+      "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
       "requires": {
-        "@babel/parser": "^7.29.2",
-        "@vue/shared": "3.5.33",
+        "@babel/parser": "^7.29.3",
+        "@vue/shared": "3.5.34",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
@@ -15451,37 +15451,37 @@
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
-      "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
+      "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
       "requires": {
-        "@vue/compiler-core": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-core": "3.5.34",
+        "@vue/shared": "3.5.34"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
-      "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
+      "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
       "requires": {
-        "@babel/parser": "^7.29.2",
-        "@vue/compiler-core": "3.5.33",
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/compiler-ssr": "3.5.33",
-        "@vue/shared": "3.5.33",
+        "@babel/parser": "^7.29.3",
+        "@vue/compiler-core": "3.5.34",
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.10",
+        "postcss": "^8.5.14",
         "source-map-js": "^1.2.1"
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
-      "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
+      "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
       "requires": {
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/shared": "3.5.34"
       }
     },
     "@vue/devtools-api": {
@@ -15600,46 +15600,46 @@
       }
     },
     "@vue/reactivity": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
-      "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
+      "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
       "requires": {
-        "@vue/shared": "3.5.33"
+        "@vue/shared": "3.5.34"
       }
     },
     "@vue/runtime-core": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
-      "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
+      "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
       "requires": {
-        "@vue/reactivity": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/reactivity": "3.5.34",
+        "@vue/shared": "3.5.34"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
-      "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
+      "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
       "requires": {
-        "@vue/reactivity": "3.5.33",
-        "@vue/runtime-core": "3.5.33",
-        "@vue/shared": "3.5.33",
+        "@vue/reactivity": "3.5.34",
+        "@vue/runtime-core": "3.5.34",
+        "@vue/shared": "3.5.34",
         "csstype": "^3.2.3"
       }
     },
     "@vue/server-renderer": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
-      "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
+      "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
       "requires": {
-        "@vue/compiler-ssr": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34"
       }
     },
     "@vue/shared": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
-      "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ=="
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
+      "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA=="
     },
     "@vue/test-utils": {
       "version": "2.4.10",
@@ -19914,15 +19914,15 @@
       "dev": true
     },
     "vue": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
-      "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
+      "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
       "requires": {
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/compiler-sfc": "3.5.33",
-        "@vue/runtime-dom": "3.5.33",
-        "@vue/server-renderer": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-sfc": "3.5.34",
+        "@vue/runtime-dom": "3.5.34",
+        "@vue/server-renderer": "3.5.34",
+        "@vue/shared": "3.5.34"
       }
     },
     "vue-component-type-helpers": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "pinia": "^3.0.4",
-    "vue": "^3.5.33",
+    "vue": "^3.5.34",
     "vue-router": "^5.0.6"
   },
   "devDependencies": {
@@ -30,7 +30,7 @@
     "@tailwindcss/postcss": "^4.2.4",
     "@vitejs/plugin-vue": "^6.0.6",
     "@vitest/coverage-v8": "^4.1.5",
-    "@vue/compiler-sfc": "^3.5.33",
+    "@vue/compiler-sfc": "^3.5.34",
     "@vue/eslint-config-standard": "^9.0.1",
     "@vue/test-utils": "^2.4.10",
     "@vue/tsconfig": "^0.9.1",


### PR DESCRIPTION
## Summary
- Patch bump `vue` and `@vue/compiler-sfc` 3.5.33 → 3.5.34.

## Test plan
- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run test:unit` (23/23)
- [x] `npm run build` (PWA artifacts present, bundle sizes unchanged)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)