### PR TITLE
refactor(store): move item mutations into store actions

### DIFF
--- a/src/classes/Item.ts
+++ b/src/classes/Item.ts
@@ -3,12 +3,12 @@ import { v4 as uuidv4 } from 'uuid'
 export default class Item {
   id: string
   n: string
-  q: number | string
+  q: string
   c: number
   u: number
   d: number
 
-  constructor (name: string, quantity: number | string) {
+  constructor (name: string, quantity: string) {
     this.id = uuidv4().substring(0, 8)
     this.n = name
     this.q = quantity

--- a/src/stores/lists.ts
+++ b/src/stores/lists.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
 import type List from '@/classes/List'
+import type Item from '@/classes/Item'
 
 export const useListsStore = defineStore('lists', () => {
   const lists = ref<List[]>([])
@@ -18,15 +19,16 @@ export const useListsStore = defineStore('lists', () => {
     if (raw) lists.value = JSON.parse(raw)
   }
 
-  function createList (list: List) {
-    lists.value.push(list)
+  function writeList (listId: string, mutator: (list: List) => void) {
+    const list = lists.value.find(l => l.id === listId)
+    if (!list) return
+    mutator(list)
+    list.i.sort((a, b) => a.n.localeCompare(b.n, undefined, { sensitivity: 'base' }))
     persist()
   }
 
-  function updateList (list: List) {
-    list.i.sort((a, b) => a.n.localeCompare(b.n, undefined, { sensitivity: 'base' }))
-    const i = lists.value.findIndex(l => l.id === list.id)
-    lists.value[i] = list
+  function createList (list: List) {
+    lists.value.push(list)
     persist()
   }
 
@@ -35,5 +37,30 @@ export const useListsStore = defineStore('lists', () => {
     persist()
   }
 
-  return { lists, getListFromId, init, createList, updateList, deleteList }
+  function addItem (listId: string, item: Item) {
+    writeList(listId, l => { l.i.push(item) })
+  }
+
+  function updateItem (listId: string, itemId: string, patch: Partial<Item>) {
+    writeList(listId, l => {
+      const item = l.i.find(i => i.id === itemId)
+      if (!item) return
+      Object.assign(item, patch, { u: Date.now() })
+    })
+  }
+
+  function softDeleteItem (listId: string, itemId: string) {
+    updateItem(listId, itemId, { d: 1 })
+  }
+
+  return {
+    lists,
+    getListFromId,
+    init,
+    createList,
+    deleteList,
+    addItem,
+    updateItem,
+    softDeleteItem
+  }
 })

--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -99,10 +99,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, nextTick } from 'vue'
+import { computed, ref, onMounted, nextTick } from 'vue'
 import { useRoute } from 'vue-router'
 import Item from '@/classes/Item'
-import type List from '@/classes/List'
 import { useListsStore } from '@/stores/lists'
 import { useLiveRegion } from '@/composables/useLiveRegion'
 
@@ -110,66 +109,45 @@ const route = useRoute()
 const listsStore = useListsStore()
 const { announce } = useLiveRegion()
 
-const list = ref<List | null>(null)
+const listId = route.params.id as string
+const list = computed(() => listsStore.getListFromId(listId))
 const name = ref<string | null>(null)
 const quantity = ref<number>(1)
 const itemName = ref<HTMLInputElement | null>(null)
 
-function findItem (id: string): Item | undefined {
-  return list.value!.i.find(i => i.id === id)
-}
-
-function updateLocalList (): void {
-  list.value = listsStore.getListFromId(route.params.id as string) ?? null
-}
-
 function addItemToList (): void {
   const addedName = name.value!
-  const item = new Item(addedName, quantity.value)
-  list.value!.i.push(item)
-  listsStore.updateList(list.value!)
+  listsStore.addItem(listId, new Item(addedName, String(quantity.value)))
   name.value = null
   quantity.value = 1
-  updateLocalList()
   announce(`${addedName} added`)
   itemName.value!.focus()
 }
 
 function modifyItemQuantity (event: Event, id: string): void {
   const input = event.target as HTMLInputElement
-  const item = findItem(id)!
+  const item = list.value!.i.find(i => i.id === id)!
   if (input.value && !isNaN(Number(input.value))) {
-    item.q = input.value
-    item.u = new Date().getTime()
-    listsStore.updateList(list.value!)
-    updateLocalList()
+    listsStore.updateItem(listId, id, { q: input.value })
   } else {
-    input.value = String(item.q)
+    input.value = item.q
   }
 }
 
 function modifyItemName (event: Event, id: string): void {
   const input = event.target as HTMLInputElement
   if (input.value) {
-    const item = findItem(id)!
-    item.n = input.value
-    item.u = new Date().getTime()
-    listsStore.updateList(list.value!)
-    updateLocalList()
+    listsStore.updateItem(listId, id, { n: input.value })
   }
 }
 
 async function deleteItem (id: string): Promise<void> {
-  const item = findItem(id)
+  const item = list.value!.i.find(i => i.id === id)
   if (!item) return
   const deletedName = item.n
-  item.u = new Date().getTime()
-  item.d = 1
-  listsStore.updateList(list.value!)
-  updateLocalList()
+  listsStore.softDeleteItem(listId, id)
   announce(`${deletedName} removed`)
   await nextTick()
-  // Move focus to the next visible item's name input, or back to add-item input
   const nextInput = document.querySelector<HTMLInputElement>('.item__name')
   if (nextInput) {
     nextInput.focus()
@@ -179,17 +157,14 @@ async function deleteItem (id: string): Promise<void> {
 }
 
 function toggleItemCheckedStatus (id: string): void {
-  const item = findItem(id)
-  if (item) {
-    item.c = item.c === 0 ? 1 : 0
-    item.u = new Date().getTime()
-    listsStore.updateList(list.value!)
-    announce(`${item.n} ${item.c === 1 ? 'checked' : 'unchecked'}`)
-  }
+  const item = list.value!.i.find(i => i.id === id)
+  if (!item) return
+  const next = item.c === 0 ? 1 : 0
+  listsStore.updateItem(listId, id, { c: next })
+  announce(`${item.n} ${next === 1 ? 'checked' : 'unchecked'}`)
 }
 
 onMounted(async () => {
-  updateLocalList()
   document.title = list.value!.n + ' List | Groceries List'
   await nextTick()
   itemName.value?.focus()

--- a/tests/unit/stores/lists.spec.js
+++ b/tests/unit/stores/lists.spec.js
@@ -45,34 +45,22 @@ describe('lists store', () => {
     expect(JSON.parse(localStorage.getItem('lists'))).toHaveLength(0)
   })
 
-  it('updateList replaces the entry and persists', () => {
+  it('addItem sorts items alphabetically by name', () => {
     const store = useListsStore()
-    const list = new List('Old', [])
+    const list = new List('Fruit', [])
     store.createList(list)
-    list.n = 'New'
-    store.updateList(list)
-    expect(store.lists[0].n).toBe('New')
-    expect(JSON.parse(localStorage.getItem('lists'))[0].n).toBe('New')
-  })
-
-  it('updateList sorts items alphabetically by name', () => {
-    const store = useListsStore()
-    const b = new Item('Bananas', 1)
-    const a = new Item('Apples', 2)
-    const list = new List('Fruit', [b, a])
-    store.createList(list)
-    store.updateList(store.lists[0])
+    store.addItem(list.id, new Item('Bananas', '1'))
+    store.addItem(list.id, new Item('Apples', '2'))
     expect(store.lists[0].i[0].n).toBe('Apples')
     expect(store.lists[0].i[1].n).toBe('Bananas')
   })
 
-  it('updateList sorts case-insensitively', () => {
+  it('addItem sorts case-insensitively', () => {
     const store = useListsStore()
-    const b = new Item('banana', 1)
-    const a = new Item('Apple', 2)
-    const list = new List('Fruit', [b, a])
+    const list = new List('Fruit', [])
     store.createList(list)
-    store.updateList(store.lists[0])
+    store.addItem(list.id, new Item('banana', '1'))
+    store.addItem(list.id, new Item('Apple', '2'))
     expect(store.lists[0].i[0].n).toBe('Apple')
     expect(store.lists[0].i[1].n).toBe('banana')
   })


### PR DESCRIPTION
## Summary

- Adds `addItem`, `updateItem`, `softDeleteItem` actions on the lists store; private `writeList` helper centralizes lookup, sort, persist.
- Drops `updateList` (whole-list replace) — no callers remain.
- `src/views/List.vue` dispatches actions instead of mutating store objects directly. View handlers shrink to dispatch + announce.
- `Item.q` typed as `string` to match DOM `input.value` reality and kill silent number↔string drift (no arithmetic is performed on `q` anywhere).

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run test:coverage` — 24/24 unit, coverage 83/83/84/85 over 80/75/80/80 thresholds
- [x] Spot-check in browser: add item, edit name, edit qty, toggle check, delete, reload