### PR TITLE
feat(share): QR + fragment-routed sharing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "grocerieslist.app",
       "version": "0.1.0",
       "dependencies": {
+        "pako": "^2.1.0",
         "pinia": "^3.0.4",
+        "qrcode": "^1.5.4",
         "vue": "^3.5.34",
         "vue-router": "^5.0.6"
       },
@@ -21,6 +23,8 @@
         "@pinia/testing": "^1.0.3",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4.2.4",
+        "@types/pako": "^2.0.4",
+        "@types/qrcode": "^1.5.6",
         "@vitejs/plugin-vue": "^6.0.6",
         "@vitest/coverage-v8": "^4.1.5",
         "@vue/compiler-sfc": "^3.5.34",
@@ -4054,6 +4058,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -5706,6 +5737,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001791",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
@@ -5784,6 +5824,108 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/comment-parser": {
       "version": "1.4.6",
@@ -5991,6 +6133,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -6060,6 +6211,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6177,8 +6334,7 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/enhanced-resolve": {
       "version": "5.21.0",
@@ -7443,6 +7599,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -7651,6 +7820,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -9230,6 +9408,18 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -9841,12 +10031,54 @@
         "@oxc-resolver/binding-win32-x64-msvc": "5.3.0"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parse5": {
       "version": "8.0.1",
@@ -9872,7 +10104,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10025,6 +10256,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -10100,6 +10340,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/quansync": {
@@ -10253,6 +10510,15 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -10262,6 +10528,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -10595,6 +10867,12 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -11559,6 +11837,13 @@
         "node": ">=20.18.1"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
@@ -12237,6 +12522,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -12599,26 +12890,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -12674,6 +12945,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -12694,6 +12971,85 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {
@@ -14981,6 +15337,30 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "dev": true
+    },
+    "@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -16023,6 +16403,11 @@
         "get-intrinsic": "^1.3.0"
       }
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
     "caniuse-lite": {
       "version": "1.0.30001791",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
@@ -16061,6 +16446,77 @@
         "slice-ansi": "^8.0.0",
         "string-width": "^8.2.0"
       }
+    },
+    "cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "comment-parser": {
       "version": "1.4.6",
@@ -16197,6 +16653,11 @@
         "ms": "^2.1.3"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
+    },
     "decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -16242,6 +16703,11 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true
+    },
+    "dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="
     },
     "dunder-proto": {
       "version": "1.0.1",
@@ -16322,8 +16788,7 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "enhanced-resolve": {
       "version": "5.21.0",
@@ -17145,6 +17610,15 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
     "flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -17279,6 +17753,11 @@
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-east-asian-width": {
       "version": "1.5.0",
@@ -18206,6 +18685,14 @@
         "quansync": "^0.2.11"
       }
     },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -18618,11 +19105,37 @@
         "@oxc-resolver/binding-win32-x64-msvc": "5.3.0"
       }
     },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
     "package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true
+    },
+    "pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "parse5": {
       "version": "8.0.1",
@@ -18642,8 +19155,7 @@
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-parse": {
       "version": "1.0.7",
@@ -18742,6 +19254,11 @@
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true
     },
+    "pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
+    },
     "possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -18781,6 +19298,16 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true
+    },
+    "qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "requires": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      }
     },
     "quansync": {
       "version": "0.2.11",
@@ -18872,11 +19399,21 @@
         "jsesc": "~3.1.0"
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+    },
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "resolve": {
       "version": "1.22.12",
@@ -19098,6 +19635,11 @@
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
       "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "set-function-length": {
       "version": "1.2.2",
@@ -19732,6 +20274,12 @@
       "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true
     },
+    "undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
@@ -20093,6 +20641,11 @@
         "is-weakset": "^2.0.3"
       }
     },
+    "which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
+    },
     "which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -20386,21 +20939,6 @@
             "color-convert": "^2.0.1"
           }
         },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -20441,6 +20979,11 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
+    "y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    },
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -20451,6 +20994,63 @@
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog=="
+    },
+    "yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "requires": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "pako": "^2.1.0",
     "pinia": "^3.0.4",
+    "qrcode": "^1.5.4",
     "vue": "^3.5.34",
     "vue-router": "^5.0.6"
   },
@@ -28,6 +30,8 @@
     "@pinia/testing": "^1.0.3",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4.2.4",
+    "@types/pako": "^2.0.4",
+    "@types/qrcode": "^1.5.6",
     "@vitejs/plugin-vue": "^6.0.6",
     "@vitest/coverage-v8": "^4.1.5",
     "@vue/compiler-sfc": "^3.5.34",

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,23 +9,95 @@
         </transition>
       </router-view>
     </main>
+    <import-modal v-if="pendingImport"
+                  v-model:open="importOpen"
+                  :incoming="pendingImport"
+                  :existing="existingMatch"
+                  @replace="onReplace"
+                  @merge="onMerge"
+                  @copy="onCopy"
+                  @cancel="onCancel"/>
     <div aria-live="polite" aria-atomic="true" class="sr-only">{{ liveMessage }}</div>
   </div>
 </template>
 
-<script setup>
-import { ref, onMounted } from 'vue'
+<script setup lang="ts">
+import { ref, shallowRef, onMounted, onUnmounted } from 'vue'
+import { useRouter } from 'vue-router'
 import AppHeader from '@/components/AppHeader.vue'
+import ImportModal from '@/components/ImportModal.vue'
 import { useListsStore } from '@/stores/lists'
 import { useLiveRegion } from '@/composables/useLiveRegion'
+import type List from '@/classes/List'
 
+const router = useRouter()
 const listsStore = useListsStore()
 const loaded = ref(false)
-const { message: liveMessage } = useLiveRegion()
+const { message: liveMessage, announce } = useLiveRegion()
 
-onMounted(() => {
+const importOpen = ref(false)
+const pendingImport = shallowRef<List | null>(null)
+const existingMatch = shallowRef<List | null>(null)
+
+async function handleImportFragment () {
+  const m = /^#import=(.+)$/.exec(window.location.hash)
+  if (!m) return
+  history.replaceState({}, '', window.location.pathname + window.location.search)
+
+  const { decodeList } = await import('@/utils/share')
+  const result = decodeList(m[1])
+  if (!result.ok) {
+    announce(result.reason === 'newer-schema'
+      ? 'This list was shared from a newer version. Update the app to import it.'
+      : "Couldn't read shared list — try rescanning.")
+    return
+  }
+  pendingImport.value = result.list
+  existingMatch.value = listsStore.getListFromId(result.list.id) ?? null
+  importOpen.value = true
+}
+
+function finishImport (id: string, message: string) {
+  importOpen.value = false
+  announce(message)
+  router.replace({ name: 'List', params: { id } })
+}
+
+function onReplace () {
+  if (!pendingImport.value) return
+  const { id, n } = pendingImport.value
+  listsStore.replaceList(pendingImport.value)
+  finishImport(id, `Imported "${n}"`)
+}
+
+function onMerge () {
+  if (!pendingImport.value) return
+  const { id, n } = pendingImport.value
+  listsStore.mergeList(pendingImport.value)
+  finishImport(id, `Merged "${n}"`)
+}
+
+function onCopy () {
+  if (!pendingImport.value) return
+  const { n } = pendingImport.value
+  const newId = listsStore.importAsCopy(pendingImport.value)
+  finishImport(newId, `Imported "${n}" as a new list`)
+}
+
+function onCancel () {
+  pendingImport.value = null
+  existingMatch.value = null
+}
+
+onMounted(async () => {
   listsStore.init()
   loaded.value = true
+  await handleImportFragment()
+  window.addEventListener('hashchange', handleImportFragment)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('hashchange', handleImportFragment)
 })
 </script>
 

--- a/src/components/ImportModal.vue
+++ b/src/components/ImportModal.vue
@@ -10,13 +10,13 @@
         {{ existing ? 'Update existing list?' : 'Import shared list?' }}
       </h2>
 
-      <div class="import-modal__preview">
+      <p class="import-modal__meta">
         <strong>{{ incoming.n }}</strong>
-        <span class="import-modal__count">{{ liveItemCount }} item<span v-if="liveItemCount !== 1">s</span></span>
-      </div>
+        <span class="import-modal__count"> · {{ liveItemCount }} item<span v-if="liveItemCount !== 1">s</span></span>
+      </p>
 
       <p v-if="existing" class="import-modal__warning">
-        You already have a list named "{{ existing.n }}". Choose how to handle the import.
+        Choose how to handle the import.
       </p>
 
       <div class="import-modal__actions">
@@ -114,14 +114,13 @@ watch(() => props.open, (isOpen) => {
     @apply text-lg font-bold mb-3;
   }
 
-  &__preview {
-    @apply flex items-baseline justify-between bg-gl-lightgray rounded p-3 mb-3;
-    @apply dark:bg-gl-deep-blue;
+  &__meta {
+    @apply mb-3 text-sm;
   }
 
   &__count {
-    @apply text-sm text-gray-600;
-    @apply dark:text-gray-300;
+    @apply text-gray-600;
+    @apply dark:text-gray-400;
   }
 
   &__warning {
@@ -134,7 +133,7 @@ watch(() => props.open, (isOpen) => {
 
   &__button {
     @apply w-full py-3 px-4 rounded border border-gl-gray font-medium transition duration-200 ease-in-out;
-    @apply dark:border-gl-deep-blue;
+    @apply dark:bg-gl-deep-blue/50 dark:border-gl-deep-blue;
 
     &:hover, &:focus {
       @apply bg-blue-50 border-blue-300 ring-2 ring-blue-300/50 outline-none;
@@ -142,8 +141,13 @@ watch(() => props.open, (isOpen) => {
     }
 
     &--primary {
-      @apply bg-gl-darkblue text-white border-gl-darkblue;
-      @apply dark:bg-gl-deep-blue dark:border-gl-deep-blue;
+      @apply bg-gl-lightgreen border-gl-green text-gray-800;
+      @apply dark:bg-gl-green dark:border-gl-lightgreen dark:text-gray-200;
+
+      &:hover, &:focus {
+        @apply bg-green-300 ring-4 ring-gl-lightgreen/50 border-gl-green;
+        @apply dark:bg-green-800 dark:ring-gl-green/30 dark:border-gl-lightgreen;
+      }
     }
 
     &--cancel {

--- a/src/components/ImportModal.vue
+++ b/src/components/ImportModal.vue
@@ -1,0 +1,154 @@
+<template>
+  <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/no-static-element-interactions -->
+  <dialog ref="dialog"
+          class="import-modal"
+          aria-labelledby="import-modal-title"
+          @click="onBackdropClick"
+          @close="onCancel">
+    <div class="import-modal__panel" @click.stop>
+      <h2 id="import-modal-title" class="import-modal__title">
+        {{ existing ? 'Update existing list?' : 'Import shared list?' }}
+      </h2>
+
+      <div class="import-modal__preview">
+        <strong>{{ incoming.n }}</strong>
+        <span class="import-modal__count">{{ liveItemCount }} item<span v-if="liveItemCount !== 1">s</span></span>
+      </div>
+
+      <p v-if="existing" class="import-modal__warning">
+        You already have a list named "{{ existing.n }}". Choose how to handle the import.
+      </p>
+
+      <div class="import-modal__actions">
+        <template v-if="existing">
+          <button type="button"
+                  class="import-modal__button import-modal__button--primary"
+                  @click="emit('merge')">
+            Merge
+          </button>
+          <button type="button"
+                  class="import-modal__button"
+                  @click="emit('replace')">
+            Replace mine
+          </button>
+          <button type="button"
+                  class="import-modal__button"
+                  @click="emit('copy')">
+            Import as copy
+          </button>
+        </template>
+        <template v-else>
+          <button type="button"
+                  class="import-modal__button import-modal__button--primary"
+                  @click="emit('replace')">
+            Import
+          </button>
+        </template>
+        <button type="button"
+                class="import-modal__button import-modal__button--cancel"
+                @click="onCancel">
+          Cancel
+        </button>
+      </div>
+    </div>
+  </dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import type List from '@/classes/List'
+
+const props = defineProps<{
+  open: boolean
+  incoming: List
+  existing: List | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:open', value: boolean): void
+  (e: 'replace'): void
+  (e: 'merge'): void
+  (e: 'copy'): void
+  (e: 'cancel'): void
+}>()
+
+const dialog = ref<HTMLDialogElement | null>(null)
+
+const liveItemCount = computed(() => props.incoming.i.filter(it => !it.d).length)
+
+function onCancel () {
+  emit('cancel')
+  emit('update:open', false)
+}
+
+function onBackdropClick (event: MouseEvent) {
+  if (event.target === dialog.value) onCancel()
+}
+
+onMounted(() => {
+  if (props.open) dialog.value?.showModal()
+})
+
+watch(() => props.open, (isOpen) => {
+  if (isOpen && !dialog.value?.open) dialog.value?.showModal()
+  else if (!isOpen && dialog.value?.open) dialog.value.close()
+})
+</script>
+
+<style lang="scss">
+@reference "../assets/main.css";
+
+.import-modal {
+  @apply m-auto w-full max-w-sm rounded-lg border border-gl-gray bg-white p-0 text-gl-darkblue shadow-lg;
+  @apply dark:border-gl-deep-blue dark:bg-gl-darkblue dark:text-white;
+
+  &::backdrop {
+    @apply bg-black/50;
+  }
+
+  &__panel {
+    @apply p-6;
+  }
+
+  &__title {
+    @apply text-lg font-bold mb-3;
+  }
+
+  &__preview {
+    @apply flex items-baseline justify-between bg-gl-lightgray rounded p-3 mb-3;
+    @apply dark:bg-gl-deep-blue;
+  }
+
+  &__count {
+    @apply text-sm text-gray-600;
+    @apply dark:text-gray-300;
+  }
+
+  &__warning {
+    @apply text-sm mb-3;
+  }
+
+  &__actions {
+    @apply grid gap-2;
+  }
+
+  &__button {
+    @apply w-full py-3 px-4 rounded border border-gl-gray font-medium transition duration-200 ease-in-out;
+    @apply dark:border-gl-deep-blue;
+
+    &:hover, &:focus {
+      @apply bg-blue-50 border-blue-300 ring-2 ring-blue-300/50 outline-none;
+      @apply dark:bg-gl-deep-blue dark:border-gl-darkblue dark:ring-gl-darkblue;
+    }
+
+    &--primary {
+      @apply bg-gl-darkblue text-white border-gl-darkblue;
+      @apply dark:bg-gl-deep-blue dark:border-gl-deep-blue;
+    }
+
+    &--cancel {
+      @apply mt-2;
+    }
+  }
+}
+</style>

--- a/src/components/ShareSheet.vue
+++ b/src/components/ShareSheet.vue
@@ -186,7 +186,7 @@ onUnmounted(() => {
 
   &__too-large {
     @apply bg-blue-50 rounded p-4 text-gl-darkblue;
-    @apply dark:bg-gl-deep-blue dark:text-white;
+    @apply dark:bg-gl-deep-blue/50 dark:text-white;
   }
 
   &__qr {

--- a/src/components/ShareSheet.vue
+++ b/src/components/ShareSheet.vue
@@ -1,0 +1,223 @@
+<template>
+  <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/no-static-element-interactions -->
+  <dialog ref="dialog"
+          class="share-sheet"
+          aria-labelledby="share-sheet-title"
+          @click="onBackdropClick"
+          @close="onClose">
+    <div class="share-sheet__panel" @click.stop>
+      <div class="share-sheet__header">
+        <h2 id="share-sheet-title" class="share-sheet__title">Share "{{ list.n }}"</h2>
+        <button type="button"
+                class="share-sheet__close"
+                aria-label="Close share sheet"
+                @click="close">
+          <font-awesome-icon icon="times-circle"/>
+        </button>
+      </div>
+
+      <div v-if="loading" class="share-sheet__loading">Generating QR code…</div>
+
+      <div v-else-if="tooLarge" class="share-sheet__too-large">
+        List too large for a QR code. Use the link instead.
+      </div>
+
+      <div v-else class="share-sheet__qr" v-html="qrSvg"/>
+
+      <div class="share-sheet__actions">
+        <button v-if="canWebShare"
+                type="button"
+                class="share-sheet__button share-sheet__button--primary"
+                :disabled="loading"
+                @click="onShare">
+          Share link…
+        </button>
+        <button type="button"
+                class="share-sheet__button"
+                :disabled="loading"
+                @click="onCopy">
+          {{ copied ? 'Copied!' : 'Copy link' }}
+        </button>
+      </div>
+    </div>
+  </dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, onMounted, onUnmounted } from 'vue'
+import type List from '@/classes/List'
+import { useLiveRegion } from '@/composables/useLiveRegion'
+
+const props = defineProps<{ open: boolean; list: List }>()
+const emit = defineEmits<{ (e: 'update:open', value: boolean): void }>()
+
+const dialog = ref<HTMLDialogElement | null>(null)
+const loading = ref(false)
+const qrSvg = ref('')
+const shareUrl = ref('')
+const tooLarge = ref(false)
+const copied = ref(false)
+const canWebShare = ref(typeof navigator !== 'undefined' && typeof navigator.share === 'function')
+const { announce } = useLiveRegion()
+
+let copyTimer: ReturnType<typeof setTimeout> | null = null
+
+async function build () {
+  loading.value = true
+  qrSvg.value = ''
+  shareUrl.value = ''
+  tooLarge.value = false
+  copied.value = false
+
+  const [{ buildShareUrl }, qrcodeMod] = await Promise.all([
+    import('@/utils/share'),
+    import('qrcode')
+  ])
+  const QRCode = qrcodeMod.default ?? qrcodeMod
+
+  const built = buildShareUrl(props.list)
+  shareUrl.value = built.url
+  tooLarge.value = built.tooLarge
+
+  if (!built.tooLarge) {
+    qrSvg.value = await QRCode.toString(built.url, {
+      type: 'svg',
+      margin: 1,
+      color: { dark: '#111827', light: '#ffffff' }
+    })
+  }
+  loading.value = false
+}
+
+function close () {
+  dialog.value?.close()
+}
+
+function onClose () {
+  emit('update:open', false)
+}
+
+function onBackdropClick (event: MouseEvent) {
+  if (event.target === dialog.value) close()
+}
+
+async function onShare () {
+  if (!shareUrl.value) return
+  try {
+    await navigator.share({
+      url: shareUrl.value,
+      title: `Groceries List: ${props.list.n}`,
+      text: `Check out my "${props.list.n}" list`
+    })
+  } catch {
+    // User cancelled or share unavailable; no-op.
+  }
+}
+
+async function onCopy () {
+  if (!shareUrl.value) return
+  try {
+    await navigator.clipboard.writeText(shareUrl.value)
+    copied.value = true
+    announce('Link copied to clipboard')
+    if (copyTimer) clearTimeout(copyTimer)
+    copyTimer = setTimeout(() => { copied.value = false }, 2000)
+  } catch {
+    announce('Could not copy link')
+  }
+}
+
+onMounted(async () => {
+  if (props.open) {
+    dialog.value?.showModal()
+    await build()
+  }
+})
+
+watch(() => props.open, async (isOpen) => {
+  if (isOpen) {
+    if (!dialog.value?.open) dialog.value?.showModal()
+    await build()
+  } else if (dialog.value?.open) {
+    dialog.value.close()
+  }
+})
+
+onUnmounted(() => {
+  if (copyTimer) clearTimeout(copyTimer)
+})
+</script>
+
+<style lang="scss">
+@reference "../assets/main.css";
+
+.share-sheet {
+  @apply m-auto w-full max-w-sm rounded-lg border border-gl-gray bg-white p-0 text-gl-darkblue shadow-lg;
+  @apply dark:border-gl-deep-blue dark:bg-gl-darkblue dark:text-white;
+
+  &::backdrop {
+    @apply bg-black/50;
+  }
+
+  &__panel {
+    @apply p-6;
+  }
+
+  &__header {
+    @apply flex items-start justify-between mb-4;
+  }
+
+  &__title {
+    @apply text-lg font-bold;
+  }
+
+  &__close {
+    @apply text-xl min-w-[44px] min-h-[44px] flex items-center justify-center -mr-2 -mt-2;
+
+    &:hover, &:focus {
+      @apply text-red-700 outline-none;
+    }
+  }
+
+  &__loading,
+  &__too-large {
+    @apply text-center py-8 text-sm;
+  }
+
+  &__too-large {
+    @apply bg-blue-50 rounded p-4 text-gl-darkblue;
+    @apply dark:bg-gl-deep-blue dark:text-white;
+  }
+
+  &__qr {
+    @apply bg-white p-4 rounded mx-auto;
+
+    svg {
+      @apply w-full h-auto block;
+    }
+  }
+
+  &__actions {
+    @apply mt-4 grid gap-2;
+  }
+
+  &__button {
+    @apply w-full py-3 px-4 rounded border border-gl-gray font-medium transition duration-200 ease-in-out;
+    @apply dark:border-gl-deep-blue;
+
+    &:hover, &:focus {
+      @apply bg-blue-50 border-blue-300 ring-2 ring-blue-300/50 outline-none;
+      @apply dark:bg-gl-deep-blue dark:border-gl-darkblue dark:ring-gl-darkblue;
+    }
+
+    &:disabled {
+      @apply opacity-50 cursor-not-allowed;
+    }
+
+    &--primary {
+      @apply bg-gl-darkblue text-white border-gl-darkblue;
+      @apply dark:bg-gl-deep-blue dark:border-gl-deep-blue;
+    }
+  }
+}
+</style>

--- a/src/components/ShareSheet.vue
+++ b/src/components/ShareSheet.vue
@@ -203,7 +203,7 @@ onUnmounted(() => {
 
   &__button {
     @apply w-full py-3 px-4 rounded border border-gl-gray font-medium transition duration-200 ease-in-out;
-    @apply dark:border-gl-deep-blue;
+    @apply dark:bg-gl-deep-blue/50 dark:border-gl-deep-blue;
 
     &:hover, &:focus {
       @apply bg-blue-50 border-blue-300 ring-2 ring-blue-300/50 outline-none;
@@ -215,8 +215,13 @@ onUnmounted(() => {
     }
 
     &--primary {
-      @apply bg-gl-darkblue text-white border-gl-darkblue;
-      @apply dark:bg-gl-deep-blue dark:border-gl-deep-blue;
+      @apply bg-gl-lightgreen border-gl-green text-gray-800;
+      @apply dark:bg-gl-green dark:border-gl-lightgreen dark:text-gray-200;
+
+      &:hover, &:focus {
+        @apply bg-green-300 ring-4 ring-gl-lightgreen/50 border-gl-green;
+        @apply dark:bg-green-800 dark:ring-gl-green/30 dark:border-gl-lightgreen;
+      }
     }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,11 +7,12 @@ import { library } from '@fortawesome/fontawesome-svg-core'
 import {
   faCheck,
   faPlusSquare,
+  faShareNodes,
   faTimesCircle
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
-library.add(faPlusSquare, faTimesCircle, faCheck)
+library.add(faPlusSquare, faTimesCircle, faCheck, faShareNodes)
 
 const app = createApp(App)
   .use(createPinia())

--- a/src/stores/lists.ts
+++ b/src/stores/lists.ts
@@ -1,7 +1,12 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
+import { v4 as uuidv4 } from 'uuid'
 import type List from '@/classes/List'
 import type Item from '@/classes/Item'
+
+function sortItems (list: List) {
+  list.i.sort((a, b) => a.n.localeCompare(b.n, undefined, { sensitivity: 'base' }))
+}
 
 export const useListsStore = defineStore('lists', () => {
   const lists = ref<List[]>([])
@@ -23,7 +28,7 @@ export const useListsStore = defineStore('lists', () => {
     const list = lists.value.find(l => l.id === listId)
     if (!list) return
     mutator(list)
-    list.i.sort((a, b) => a.n.localeCompare(b.n, undefined, { sensitivity: 'base' }))
+    sortItems(list)
     persist()
   }
 
@@ -53,6 +58,41 @@ export const useListsStore = defineStore('lists', () => {
     updateItem(listId, itemId, { d: 1 })
   }
 
+  function replaceList (incoming: List) {
+    sortItems(incoming)
+    const idx = lists.value.findIndex(l => l.id === incoming.id)
+    if (idx === -1) lists.value.push(incoming)
+    else lists.value[idx] = incoming
+    persist()
+  }
+
+  function mergeList (incoming: List) {
+    const existing = lists.value.find(l => l.id === incoming.id)
+    if (!existing) {
+      replaceList(incoming)
+      return
+    }
+    for (const inItem of incoming.i) {
+      const localIdx = existing.i.findIndex(it => it.id === inItem.id)
+      if (localIdx === -1) existing.i.push(inItem)
+      else if (inItem.u > existing.i[localIdx].u) existing.i[localIdx] = inItem
+    }
+    sortItems(existing)
+    persist()
+  }
+
+  function importAsCopy (incoming: List) {
+    const copy: List = {
+      id: uuidv4().substring(0, 8),
+      n: incoming.n,
+      i: incoming.i
+    }
+    sortItems(copy)
+    lists.value.push(copy)
+    persist()
+    return copy.id
+  }
+
   return {
     lists,
     getListFromId,
@@ -61,6 +101,9 @@ export const useListsStore = defineStore('lists', () => {
     deleteList,
     addItem,
     updateItem,
-    softDeleteItem
+    softDeleteItem,
+    replaceList,
+    mergeList,
+    importAsCopy
   }
 })

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -1,0 +1,93 @@
+import pako from 'pako'
+import type List from '@/classes/List'
+import type Item from '@/classes/Item'
+
+const SCHEMA = 1
+
+export const QR_PAYLOAD_LIMIT = 1800
+
+type ItemTuple = [string, string, string, number, number]
+type ListTuple = [string, string, ItemTuple[]]
+
+export type DecodeResult =
+  | { ok: true; list: List }
+  | { ok: false; reason: 'corrupt' | 'newer-schema' }
+
+function base64urlEncode (bytes: Uint8Array): string {
+  let bin = ''
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function base64urlDecode (s: string): Uint8Array {
+  const padded = s.replace(/-/g, '+').replace(/_/g, '/') +
+    '='.repeat((4 - s.length % 4) % 4)
+  const bin = atob(padded)
+  const out = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+  return out
+}
+
+function listToTuple (list: List): ListTuple {
+  const items: ItemTuple[] = list.i
+    .filter(item => !item.d)
+    .map(item => [item.id, item.n, item.q, item.c, item.u])
+  return [list.id, list.n, items]
+}
+
+function tupleToList (t: unknown): List {
+  if (!Array.isArray(t) || t.length !== 3) throw new Error('shape')
+  const [id, n, items] = t as [unknown, unknown, unknown]
+  if (typeof id !== 'string' || typeof n !== 'string' || !Array.isArray(items)) {
+    throw new Error('shape')
+  }
+  const i: Item[] = items.map(it => {
+    if (!Array.isArray(it) || it.length !== 5) throw new Error('shape')
+    const [iid, iname, iq, ic, iu] = it as [unknown, unknown, unknown, unknown, unknown]
+    if (typeof iid !== 'string' || typeof iname !== 'string' || typeof iq !== 'string' ||
+        typeof ic !== 'number' || typeof iu !== 'number') {
+      throw new Error('shape')
+    }
+    return { id: iid, n: iname, q: iq, c: ic, u: iu, d: 0 }
+  })
+  return { id, n, i } as List
+}
+
+export function encodeList (list: List): string {
+  const tuple = listToTuple(list)
+  const json = JSON.stringify(tuple)
+  const compressed = pako.deflate(json)
+  return String(SCHEMA) + base64urlEncode(compressed)
+}
+
+export function decodeList (payload: string): DecodeResult {
+  if (!payload || payload.length < 2) return { ok: false, reason: 'corrupt' }
+  const version = parseInt(payload[0], 10)
+  if (Number.isNaN(version)) return { ok: false, reason: 'corrupt' }
+  if (version > SCHEMA) return { ok: false, reason: 'newer-schema' }
+  if (version !== SCHEMA) return { ok: false, reason: 'corrupt' }
+  try {
+    const bytes = base64urlDecode(payload.slice(1))
+    const json = pako.inflate(bytes, { to: 'string' })
+    const tuple: unknown = JSON.parse(json)
+    return { ok: true, list: tupleToList(tuple) }
+  } catch {
+    return { ok: false, reason: 'corrupt' }
+  }
+}
+
+export function buildShareUrl (list: List, origin: string = window.location.origin): {
+  url: string
+  payload: string
+  tooLarge: boolean
+} {
+  const payload = encodeList(list)
+  const url = `${origin}/#import=${payload}`
+  return { url, payload, tooLarge: url.length > QR_PAYLOAD_LIMIT }
+}
+
+export function parseImportFragment (hash: string): string | null {
+  if (!hash) return null
+  const m = /^#import=(.+)$/.exec(hash)
+  return m ? m[1] : null
+}

--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -1,6 +1,16 @@
 <template>
   <div v-if="list">
-    <h1>{{ list.n }}</h1>
+    <div class="list-header">
+      <h1 class="list-header__title">{{ list.n }}</h1>
+      <button type="button"
+              :aria-label="`Share your ${list.n} list`"
+              class="list-header__share"
+              @click="shareOpen = true">
+        <font-awesome-icon icon="share-nodes"/>
+      </button>
+    </div>
+
+    <share-sheet v-model:open="shareOpen" :list="list"/>
 
     <form class="new-item" @submit.prevent="addItemToList">
       <label for="name" class="sr-only">Item Name</label>
@@ -104,6 +114,7 @@ import { useRoute } from 'vue-router'
 import Item from '@/classes/Item'
 import { useListsStore } from '@/stores/lists'
 import { useLiveRegion } from '@/composables/useLiveRegion'
+import ShareSheet from '@/components/ShareSheet.vue'
 
 const route = useRoute()
 const listsStore = useListsStore()
@@ -114,6 +125,7 @@ const list = computed(() => listsStore.getListFromId(listId))
 const name = ref<string | null>(null)
 const quantity = ref<number>(1)
 const itemName = ref<HTMLInputElement | null>(null)
+const shareOpen = ref(false)
 
 function addItemToList (): void {
   const addedName = name.value!
@@ -173,6 +185,23 @@ onMounted(async () => {
 
 <style lang="scss">
 @reference "../assets/main.css";
+
+.list-header {
+  @apply flex items-center justify-between mb-4;
+
+  &__title {
+    @apply text-2xl font-bold text-center mb-0;
+  }
+
+  &__share {
+    @apply flex items-center justify-center min-w-[44px] min-h-[44px] text-xl rounded-full transition duration-200 ease-in-out;
+
+    &:hover, &:focus {
+      @apply bg-blue-50 ring-2 ring-blue-300/50 outline-none;
+      @apply dark:bg-gl-deep-blue dark:ring-gl-darkblue;
+    }
+  }
+}
 
 .new-item {
   @apply flex justify-center items-center;

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -91,3 +91,52 @@ test('a11y: Lists route — after creating a list', async ({ page }) => {
   await expect(page.getByRole('link', { name: /A11y Test/ })).toBeVisible()
   await checkA11y(page)
 })
+
+test('share import: fragment payload imports list and navigates', async ({ page }) => {
+  const { encodeList } = await import('../../src/utils/share')
+  const list = {
+    id: 'shr1234a',
+    n: 'Shared Costco',
+    i: [
+      { id: 'sit00001', n: 'Bread', q: '1', c: 0, u: 1700000000000, d: 0 },
+      { id: 'sit00002', n: 'Eggs', q: '12', c: 0, u: 1700000000001, d: 0 }
+    ]
+  }
+  const payload = encodeList(list)
+
+  await page.goto(`/#import=${payload}`)
+
+  await expect(page.getByRole('heading', { name: 'Import shared list?' })).toBeVisible()
+  await expect(page.getByText('Shared Costco')).toBeVisible()
+  await page.getByRole('button', { name: 'Import' }).click()
+
+  await expect(page).toHaveURL(`/${list.id}`)
+  await expect(page.getByRole('heading', { level: 1, name: 'Shared Costco' })).toBeVisible()
+  await expect(page.locator('.item__name').first()).toHaveValue('Bread')
+})
+
+test('share import: merge keeps newer local edits', async ({ page }) => {
+  const { encodeList } = await import('../../src/utils/share')
+  const list = {
+    id: 'shr5678b',
+    n: 'Pantry',
+    i: [{ id: 'sit10001', n: 'Flour', q: '1', c: 0, u: 100, d: 0 }]
+  }
+
+  await page.addInitScript((seed) => {
+    localStorage.setItem('lists', JSON.stringify([{
+      id: seed.id,
+      n: seed.n,
+      i: [{ id: 'sit10001', n: 'Flour', q: '5', c: 0, u: 999, d: 0 }]
+    }]))
+  }, list)
+
+  const payload = encodeList(list)
+  await page.goto(`/#import=${payload}`)
+
+  await expect(page.getByRole('heading', { name: 'Update existing list?' })).toBeVisible()
+  await page.getByRole('button', { name: 'Merge' }).click()
+
+  await expect(page).toHaveURL(`/${list.id}`)
+  await expect(page.locator('.item__quantity__input').first()).toHaveValue('5')
+})

--- a/tests/unit/App.spec.js
+++ b/tests/unit/App.spec.js
@@ -1,0 +1,56 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import App from '@/App.vue'
+
+const makeRouter = () => createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/', name: 'Lists', component: { template: '<div data-test="lists"/>' } },
+    { path: '/new', name: 'New', component: { template: '<div data-test="new"/>' } },
+    { path: '/:id', name: 'List', component: { template: '<div data-test="list"/>' } }
+  ]
+})
+
+const mountApp = async () => {
+  const router = makeRouter()
+  await router.push('/')
+  const wrapper = mount(App, {
+    global: {
+      plugins: [createPinia(), router],
+      stubs: { FontAwesomeIcon: { template: '<span/>' } }
+    },
+    attachTo: document.body
+  })
+  await flushPromises()
+  return { wrapper, router }
+}
+
+describe('App.vue', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    window.location.hash = ''
+    HTMLDialogElement.prototype.showModal = vi.fn(function () { this.open = true })
+    HTMLDialogElement.prototype.close = vi.fn(function () {
+      this.open = false
+      this.dispatchEvent(new Event('close'))
+    })
+  })
+
+  it('renders header and main once loaded', async () => {
+    const { wrapper } = await mountApp()
+    expect(wrapper.html()).toContain('Skip to main content')
+    expect(wrapper.find('main').exists()).toBe(true)
+  })
+
+  it('does not show import modal without #import= fragment', async () => {
+    const { wrapper } = await mountApp()
+    expect(wrapper.find('.import-modal').exists()).toBe(false)
+  })
+
+  it('renders the live region container', async () => {
+    const { wrapper } = await mountApp()
+    expect(wrapper.find('[aria-live="polite"]').exists()).toBe(true)
+  })
+})

--- a/tests/unit/components/ImportModal.spec.js
+++ b/tests/unit/components/ImportModal.spec.js
@@ -1,0 +1,64 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import ImportModal from '@/components/ImportModal.vue'
+
+const incoming = { id: 'a1b2c3d4', n: 'Costco', i: [{ id: 'i1', n: 'Eggs', q: '1', c: 0, u: 1, d: 0 }] }
+const existing = { id: 'a1b2c3d4', n: 'Old Costco', i: [] }
+
+const mountModal = (props = {}) => mount(ImportModal, {
+  props: { open: false, incoming, existing: null, ...props },
+  global: { stubs: { FontAwesomeIcon: { template: '<span/>' } } }
+})
+
+describe('ImportModal', () => {
+  it('renders only Import + Cancel when no existing match', () => {
+    const wrapper = mountModal()
+    const buttons = wrapper.findAll('button').map(b => b.text())
+    expect(buttons).toContain('Import')
+    expect(buttons).toContain('Cancel')
+    expect(buttons).not.toContain('Merge')
+    expect(buttons).not.toContain('Replace mine')
+  })
+
+  it('renders Merge / Replace / Copy / Cancel when existing matches', () => {
+    const wrapper = mountModal({ existing })
+    const buttons = wrapper.findAll('button').map(b => b.text())
+    expect(buttons).toEqual(expect.arrayContaining(['Merge', 'Replace mine', 'Import as copy', 'Cancel']))
+  })
+
+  it('emits replace when Import is clicked (no collision)', async () => {
+    const wrapper = mountModal()
+    await wrapper.findAll('button').find(b => b.text() === 'Import').trigger('click')
+    expect(wrapper.emitted('replace')).toBeTruthy()
+  })
+
+  it('emits merge / replace / copy on the corresponding buttons', async () => {
+    const wrapper = mountModal({ existing })
+    await wrapper.findAll('button').find(b => b.text() === 'Merge').trigger('click')
+    await wrapper.findAll('button').find(b => b.text() === 'Replace mine').trigger('click')
+    await wrapper.findAll('button').find(b => b.text() === 'Import as copy').trigger('click')
+    expect(wrapper.emitted('merge')).toBeTruthy()
+    expect(wrapper.emitted('replace')).toBeTruthy()
+    expect(wrapper.emitted('copy')).toBeTruthy()
+  })
+
+  it('emits cancel + update:open=false when Cancel is clicked', async () => {
+    const wrapper = mountModal()
+    await wrapper.findAll('button').find(b => b.text() === 'Cancel').trigger('click')
+    expect(wrapper.emitted('cancel')).toBeTruthy()
+    expect(wrapper.emitted('update:open')).toEqual([[false]])
+  })
+
+  it('shows live item count, ignoring tombstones', () => {
+    const incomingWithTomb = {
+      id: 'x',
+      n: 'L',
+      i: [
+        { id: 'i1', n: 'A', q: '1', c: 0, u: 1, d: 0 },
+        { id: 'i2', n: 'B', q: '1', c: 0, u: 1, d: 1 }
+      ]
+    }
+    const wrapper = mountModal({ incoming: incomingWithTomb })
+    expect(wrapper.text()).toContain('1 item')
+  })
+})

--- a/tests/unit/components/ImportModal.spec.js
+++ b/tests/unit/components/ImportModal.spec.js
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import ImportModal from '@/components/ImportModal.vue'
 
 const incoming = { id: 'a1b2c3d4', n: 'Costco', i: [{ id: 'i1', n: 'Eggs', q: '1', c: 0, u: 1, d: 0 }] }
@@ -11,6 +11,14 @@ const mountModal = (props = {}) => mount(ImportModal, {
 })
 
 describe('ImportModal', () => {
+  beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn(function () { this.open = true })
+    HTMLDialogElement.prototype.close = vi.fn(function () {
+      this.open = false
+      this.dispatchEvent(new Event('close'))
+    })
+  })
+
   it('renders only Import + Cancel when no existing match', () => {
     const wrapper = mountModal()
     const buttons = wrapper.findAll('button').map(b => b.text())
@@ -60,5 +68,37 @@ describe('ImportModal', () => {
     }
     const wrapper = mountModal({ incoming: incomingWithTomb })
     expect(wrapper.text()).toContain('1 item')
+  })
+
+  it('calls showModal on mount when open=true', () => {
+    mountModal({ open: true })
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled()
+  })
+
+  it('calls showModal when open transitions to true', async () => {
+    const wrapper = mountModal({ open: false })
+    expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled()
+    await wrapper.setProps({ open: true })
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled()
+  })
+
+  it('calls close when open transitions to false', async () => {
+    const wrapper = mountModal({ open: true })
+    await wrapper.setProps({ open: false })
+    expect(HTMLDialogElement.prototype.close).toHaveBeenCalled()
+  })
+
+  it('cancels when backdrop is clicked (target is dialog itself)', async () => {
+    const wrapper = mountModal({ open: true })
+    const dialogEl = wrapper.find('dialog').element
+    dialogEl.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('cancel')).toBeTruthy()
+  })
+
+  it('does not cancel when click target is inside the panel', async () => {
+    const wrapper = mountModal({ open: true })
+    await wrapper.find('.import-modal__panel').trigger('click')
+    expect(wrapper.emitted('cancel')).toBeFalsy()
   })
 })

--- a/tests/unit/components/ShareSheet.spec.js
+++ b/tests/unit/components/ShareSheet.spec.js
@@ -1,0 +1,141 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import ShareSheet from '@/components/ShareSheet.vue'
+
+const { buildShareUrlMock } = vi.hoisted(() => ({ buildShareUrlMock: vi.fn() }))
+
+vi.mock('qrcode', () => ({
+  default: { toString: vi.fn().mockResolvedValue('<svg data-test="mock-qr"/>') }
+}))
+
+vi.mock('@/utils/share', () => ({
+  buildShareUrl: (...args) => buildShareUrlMock(...args)
+}))
+
+const list = { id: 'l1', n: 'Costco', i: [{ id: 'i1', n: 'Eggs', q: '1', c: 0, u: 1, d: 0 }] }
+
+const mountSheet = (props = {}) => mount(ShareSheet, {
+  props: { open: false, list, ...props },
+  global: { stubs: { FontAwesomeIcon: { template: '<span/>' } } },
+  attachTo: document.body
+})
+
+describe('ShareSheet', () => {
+  beforeEach(() => {
+    buildShareUrlMock.mockReset()
+    HTMLDialogElement.prototype.showModal = vi.fn(function () { this.open = true })
+    HTMLDialogElement.prototype.close = vi.fn(function () {
+      this.open = false
+      this.dispatchEvent(new Event('close'))
+    })
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) }
+    })
+    Object.defineProperty(navigator, 'share', {
+      configurable: true,
+      value: vi.fn().mockResolvedValue(undefined)
+    })
+  })
+
+  it('does not call showModal when mounted closed', () => {
+    const wrapper = mountSheet({ open: false })
+    expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('builds QR + URL when opened, hides loading, shows QR', async () => {
+    buildShareUrlMock.mockReturnValue({
+      url: 'https://example.com/#import=1abc',
+      payload: '1abc',
+      tooLarge: false
+    })
+    const wrapper = mountSheet({ open: true })
+    await flushPromises()
+    expect(buildShareUrlMock).toHaveBeenCalledWith(list)
+    expect(wrapper.html()).toContain('mock-qr')
+    expect(wrapper.text()).not.toContain('Generating QR code')
+    wrapper.unmount()
+  })
+
+  it('shows too-large message and skips QR rendering when payload over cap', async () => {
+    buildShareUrlMock.mockReturnValue({
+      url: 'x'.repeat(2000),
+      payload: 'x'.repeat(2000),
+      tooLarge: true
+    })
+    const wrapper = mountSheet({ open: true })
+    await flushPromises()
+    expect(wrapper.text()).toContain('List too large')
+    expect(wrapper.html()).not.toContain('mock-qr')
+    wrapper.unmount()
+  })
+
+  it('copies URL to clipboard when Copy is clicked', async () => {
+    buildShareUrlMock.mockReturnValue({ url: 'https://example.com/#x', payload: 'x', tooLarge: false })
+    const wrapper = mountSheet({ open: true })
+    await flushPromises()
+    await wrapper.findAll('button').find(b => b.text().includes('Copy link')).trigger('click')
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('https://example.com/#x')
+  })
+
+  it('invokes navigator.share when Share link is clicked', async () => {
+    buildShareUrlMock.mockReturnValue({ url: 'https://example.com/#x', payload: 'x', tooLarge: false })
+    const wrapper = mountSheet({ open: true })
+    await flushPromises()
+    await wrapper.findAll('button').find(b => b.text().includes('Share link')).trigger('click')
+    expect(navigator.share).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://example.com/#x' }))
+  })
+
+  it('emits update:open=false when close button clicked', async () => {
+    buildShareUrlMock.mockReturnValue({ url: 'x', payload: 'x', tooLarge: false })
+    const wrapper = mountSheet({ open: true })
+    await flushPromises()
+    await wrapper.find('.share-sheet__close').trigger('click')
+    await flushPromises()
+    expect(wrapper.emitted('update:open')).toEqual([[false]])
+  })
+
+  it('closes when prop transitions from open to closed', async () => {
+    buildShareUrlMock.mockReturnValue({ url: 'x', payload: 'x', tooLarge: false })
+    const wrapper = mountSheet({ open: true })
+    await flushPromises()
+    await wrapper.setProps({ open: false })
+    await flushPromises()
+    expect(HTMLDialogElement.prototype.close).toHaveBeenCalled()
+  })
+
+  it('opens via showModal when prop transitions from closed to open', async () => {
+    buildShareUrlMock.mockReturnValue({ url: 'x', payload: 'x', tooLarge: false })
+    const wrapper = mountSheet({ open: false })
+    await wrapper.setProps({ open: true })
+    await flushPromises()
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled()
+  })
+
+  it('swallows clipboard errors', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error('denied')) }
+    })
+    buildShareUrlMock.mockReturnValue({ url: 'x', payload: 'x', tooLarge: false })
+    const wrapper = mountSheet({ open: true })
+    await flushPromises()
+    await wrapper.findAll('button').find(b => b.text().includes('Copy link')).trigger('click')
+    await flushPromises()
+    expect(true).toBe(true)
+  })
+
+  it('swallows navigator.share rejection (user cancel)', async () => {
+    Object.defineProperty(navigator, 'share', {
+      configurable: true,
+      value: vi.fn().mockRejectedValue(new Error('cancelled'))
+    })
+    buildShareUrlMock.mockReturnValue({ url: 'x', payload: 'x', tooLarge: false })
+    const wrapper = mountSheet({ open: true })
+    await flushPromises()
+    await wrapper.findAll('button').find(b => b.text().includes('Share link')).trigger('click')
+    await flushPromises()
+    expect(true).toBe(true)
+  })
+})

--- a/tests/unit/stores/lists.spec.js
+++ b/tests/unit/stores/lists.spec.js
@@ -76,4 +76,99 @@ describe('lists store', () => {
     const store = useListsStore()
     expect(store.getListFromId('unknown')).toBeUndefined()
   })
+
+  describe('replaceList', () => {
+    it('adds a new list when id does not exist', () => {
+      const store = useListsStore()
+      const incoming = { id: 'abc', n: 'Costco', i: [{ id: 'i1', n: 'Eggs', q: '1', c: 0, u: 1, d: 0 }] }
+      store.replaceList(incoming)
+      expect(store.lists).toHaveLength(1)
+      expect(store.lists[0].id).toBe('abc')
+    })
+
+    it('replaces existing list wholesale when id matches', () => {
+      const store = useListsStore()
+      store.createList({ id: 'abc', n: 'Old', i: [{ id: 'i1', n: 'Stale', q: '1', c: 0, u: 1, d: 0 }] })
+      const incoming = { id: 'abc', n: 'New', i: [{ id: 'i2', n: 'Fresh', q: '1', c: 0, u: 2, d: 0 }] }
+      store.replaceList(incoming)
+      expect(store.lists).toHaveLength(1)
+      expect(store.lists[0].n).toBe('New')
+      expect(store.lists[0].i).toHaveLength(1)
+      expect(store.lists[0].i[0].id).toBe('i2')
+    })
+
+    it('sorts items after replace', () => {
+      const store = useListsStore()
+      const incoming = {
+        id: 'abc',
+        n: 'L',
+        i: [
+          { id: 'i1', n: 'Bananas', q: '1', c: 0, u: 1, d: 0 },
+          { id: 'i2', n: 'Apples', q: '1', c: 0, u: 1, d: 0 }
+        ]
+      }
+      store.replaceList(incoming)
+      expect(store.lists[0].i[0].n).toBe('Apples')
+    })
+  })
+
+  describe('mergeList', () => {
+    it('falls back to replaceList when id is unknown', () => {
+      const store = useListsStore()
+      const incoming = { id: 'abc', n: 'Costco', i: [{ id: 'i1', n: 'Eggs', q: '1', c: 0, u: 1, d: 0 }] }
+      store.mergeList(incoming)
+      expect(store.lists).toHaveLength(1)
+      expect(store.lists[0].id).toBe('abc')
+    })
+
+    it('adds incoming items not present locally', () => {
+      const store = useListsStore()
+      store.createList({ id: 'abc', n: 'L', i: [{ id: 'a', n: 'Apples', q: '1', c: 0, u: 1, d: 0 }] })
+      store.mergeList({ id: 'abc', n: 'L', i: [{ id: 'b', n: 'Bananas', q: '1', c: 0, u: 2, d: 0 }] })
+      expect(store.lists[0].i).toHaveLength(2)
+    })
+
+    it('takes incoming item when its timestamp is newer', () => {
+      const store = useListsStore()
+      store.createList({ id: 'abc', n: 'L', i: [{ id: 'a', n: 'Apples', q: '1', c: 0, u: 100, d: 0 }] })
+      store.mergeList({ id: 'abc', n: 'L', i: [{ id: 'a', n: 'Apples', q: '99', c: 0, u: 200, d: 0 }] })
+      expect(store.lists[0].i[0].q).toBe('99')
+    })
+
+    it('keeps local item when its timestamp is newer', () => {
+      const store = useListsStore()
+      store.createList({ id: 'abc', n: 'L', i: [{ id: 'a', n: 'Apples', q: '99', c: 0, u: 200, d: 0 }] })
+      store.mergeList({ id: 'abc', n: 'L', i: [{ id: 'a', n: 'Apples', q: '1', c: 0, u: 100, d: 0 }] })
+      expect(store.lists[0].i[0].q).toBe('99')
+    })
+
+    it('leaves locally-tombstoned items alone when not in incoming', () => {
+      const store = useListsStore()
+      store.createList({ id: 'abc', n: 'L', i: [{ id: 'a', n: 'Apples', q: '1', c: 0, u: 1, d: 1 }] })
+      store.mergeList({ id: 'abc', n: 'L', i: [] })
+      expect(store.lists[0].i).toHaveLength(1)
+      expect(store.lists[0].i[0].d).toBe(1)
+    })
+  })
+
+  describe('importAsCopy', () => {
+    it('creates a new list with a fresh id', () => {
+      const store = useListsStore()
+      const incoming = { id: 'abc', n: 'Costco', i: [{ id: 'i1', n: 'Eggs', q: '1', c: 0, u: 1, d: 0 }] }
+      const newId = store.importAsCopy(incoming)
+      expect(newId).not.toBe('abc')
+      expect(store.lists).toHaveLength(1)
+      expect(store.lists[0].id).toBe(newId)
+      expect(store.lists[0].n).toBe('Costco')
+    })
+
+    it('does not overwrite an existing list with the same incoming id', () => {
+      const store = useListsStore()
+      store.createList({ id: 'abc', n: 'Original', i: [] })
+      store.importAsCopy({ id: 'abc', n: 'Imported', i: [] })
+      expect(store.lists).toHaveLength(2)
+      expect(store.lists[0].n).toBe('Original')
+      expect(store.lists[1].n).toBe('Imported')
+    })
+  })
 })

--- a/tests/unit/utils/share.spec.ts
+++ b/tests/unit/utils/share.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import pako from 'pako'
+import { encodeList, decodeList, buildShareUrl, parseImportFragment, QR_PAYLOAD_LIMIT } from '@/utils/share'
+import List from '@/classes/List'
+import Item from '@/classes/Item'
+
+function toBase64Url (bytes: Uint8Array): string {
+  let bin = ''
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+describe('share encode/decode', () => {
+  it('roundtrips a list with items', () => {
+    const list = new List('Costco', [new Item('Eggs', '1'), new Item('Milk', '2')])
+    const encoded = encodeList(list)
+    const result = decodeList(encoded)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.list.id).toBe(list.id)
+    expect(result.list.n).toBe('Costco')
+    expect(result.list.i).toHaveLength(2)
+    expect(result.list.i[0]).toMatchObject({ n: 'Eggs', q: '1', c: 0, d: 0 })
+    expect(result.list.i[1]).toMatchObject({ n: 'Milk', q: '2', c: 0, d: 0 })
+  })
+
+  it('strips soft-deleted items at encode time', () => {
+    const live = new Item('Eggs', '1')
+    const dead = new Item('Milk', '1')
+    dead.d = 1
+    const list = new List('L', [live, dead])
+    const result = decodeList(encodeList(list))
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.list.i).toHaveLength(1)
+    expect(result.list.i[0].n).toBe('Eggs')
+  })
+
+  it('preserves item timestamps for merge', () => {
+    const item = new Item('Eggs', '1')
+    item.u = 1700000000000
+    item.c = 1
+    const list = new List('L', [item])
+    const result = decodeList(encodeList(list))
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.list.i[0].u).toBe(1700000000000)
+    expect(result.list.i[0].c).toBe(1)
+  })
+
+  it('rejects empty payload as corrupt', () => {
+    expect(decodeList('')).toEqual({ ok: false, reason: 'corrupt' })
+    expect(decodeList('1')).toEqual({ ok: false, reason: 'corrupt' })
+  })
+
+  it('rejects garbage base64 as corrupt', () => {
+    expect(decodeList('1!!!notbase64!!!')).toEqual({ ok: false, reason: 'corrupt' })
+  })
+
+  it('rejects valid base64 of garbage as corrupt', () => {
+    expect(decodeList('1aGVsbG8')).toEqual({ ok: false, reason: 'corrupt' })
+  })
+
+  it('rejects newer schema version', () => {
+    const list = new List('L', [])
+    const v1 = encodeList(list)
+    const v2 = '2' + v1.slice(1)
+    expect(decodeList(v2)).toEqual({ ok: false, reason: 'newer-schema' })
+  })
+
+  it('rejects non-numeric version prefix as corrupt', () => {
+    expect(decodeList('xabcdef')).toEqual({ ok: false, reason: 'corrupt' })
+  })
+
+  it('rejects shape-mismatched payload as corrupt', () => {
+    const compressed = toBase64Url(pako.deflate(JSON.stringify({ not: 'a tuple' })))
+    expect(decodeList('1' + compressed)).toEqual({ ok: false, reason: 'corrupt' })
+  })
+})
+
+describe('buildShareUrl', () => {
+  it('builds a fragment-routed URL containing the payload', () => {
+    const list = new List('L', [new Item('Eggs', '1')])
+    const { url, payload, tooLarge } = buildShareUrl(list, 'https://grocerieslist.app')
+    expect(url).toBe(`https://grocerieslist.app/#import=${payload}`)
+    expect(tooLarge).toBe(false)
+  })
+
+  it('flags tooLarge when payload exceeds the QR limit', () => {
+    const items = Array.from({ length: 500 }, (_, i) => new Item(`item-${i}-with-some-padding`, '1'))
+    const list = new List('Big', items)
+    const { tooLarge, url } = buildShareUrl(list, 'https://grocerieslist.app')
+    expect(tooLarge).toBe(true)
+    expect(url.length).toBeGreaterThan(QR_PAYLOAD_LIMIT)
+  })
+})
+
+describe('parseImportFragment', () => {
+  it('extracts payload from #import= hash', () => {
+    expect(parseImportFragment('#import=1abc')).toBe('1abc')
+  })
+
+  it('returns null for empty hash', () => {
+    expect(parseImportFragment('')).toBeNull()
+  })
+
+  it('returns null for non-import hash', () => {
+    expect(parseImportFragment('#other=1')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Replaces the retired `?import=` URL feature (commit 9739727) with a fragment-routed URL embedded in a QR code, also exposed via Web Share API + clipboard.
- Encode pipeline: strip tombstones → compact tuple → `pako.deflate` → base64url → single-char version prefix. Strict version check on decode (`corrupt` vs `newer-schema` distinguished for the toast).
- Recipient flow always prompts: three buttons (Replace / Merge / Import as copy) on id collision, single Import on no collision. `mergeList` honors per-item `u` timestamps and leaves local tombstones alone.
- Sender flow lives in the List view header (new share button). `ShareSheet` lazy-loads `pako` (~15 KB gz) and `qrcode` (~9 KB gz) only when opened — daily-driver bundle unchanged.
- Cap-and-warn at 1.8 KB total URL length; oversized lists show "too large for QR" but the link stays sharable via copy/Web Share.
- Native `<dialog showModal>` provides focus trap + escape + focus restore. `useLiveRegion` announces success/failure.

## Test plan

- [x] `npm run test:unit` — 54 unit tests pass (encode/decode roundtrip, strict version policy, tombstone strip, store actions per case, ImportModal render + emit)
- [x] `npm run test:e2e` — 9 e2e pass, including:
  - new `share import: fragment payload imports list and navigates`
  - new `share import: merge keeps newer local edits`
  - existing axe a11y suite on Lists / List / New (List route exercises the new share button)
- [x] `npm run build` — clean prod build, share/qrcode chunks split correctly
- [x] `npm run lint` — clean
- [x] `vue-tsc --noEmit` — clean
- [x] Manual: scan QR from a phone, confirm browser opens to `/#import=…` and modal appears
- [x] Manual: copy link, paste in another browser, confirm import flow
- [x] Manual: share an oversized list (~50+ items), verify "too large" message + Copy still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)