### PR TITLE
feat(lists): replace native confirm() with styled ConfirmModal

### DIFF
--- a/src/components/ConfirmModal.vue
+++ b/src/components/ConfirmModal.vue
@@ -1,0 +1,137 @@
+<template>
+  <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/no-static-element-interactions -->
+  <dialog ref="dialog"
+          class="confirm-modal"
+          :aria-labelledby="titleId"
+          :aria-describedby="messageId"
+          @click="onBackdropClick"
+          @close="onCancel">
+    <div class="confirm-modal__panel" @click.stop>
+      <h2 :id="titleId" class="confirm-modal__title">{{ title }}</h2>
+      <p :id="messageId" class="confirm-modal__message">{{ message }}</p>
+
+      <div class="confirm-modal__actions">
+        <button type="button"
+                class="confirm-modal__button"
+                @click="onCancel">
+          {{ cancelLabel }}
+        </button>
+        <button type="button"
+                class="confirm-modal__button"
+                :class="variant === 'destructive' ? 'confirm-modal__button--destructive' : 'confirm-modal__button--primary'"
+                @click="onConfirm">
+          {{ confirmLabel }}
+        </button>
+      </div>
+    </div>
+  </dialog>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, useId, watch } from 'vue'
+
+const props = withDefaults(defineProps<{
+  open: boolean
+  title: string
+  message: string
+  variant?: 'primary' | 'destructive'
+  confirmLabel?: string
+  cancelLabel?: string
+}>(), {
+  variant: 'primary',
+  confirmLabel: 'Confirm',
+  cancelLabel: 'Cancel'
+})
+
+const emit = defineEmits<{
+  (e: 'update:open', value: boolean): void
+  (e: 'confirm'): void
+  (e: 'cancel'): void
+}>()
+
+const dialog = ref<HTMLDialogElement | null>(null)
+const titleId = useId()
+const messageId = useId()
+
+function onConfirm () {
+  emit('confirm')
+  emit('update:open', false)
+}
+
+function onCancel () {
+  emit('cancel')
+  emit('update:open', false)
+}
+
+function onBackdropClick (event: MouseEvent) {
+  if (event.target === dialog.value) onCancel()
+}
+
+onMounted(() => {
+  if (props.open) dialog.value?.showModal()
+})
+
+watch(() => props.open, (isOpen) => {
+  if (isOpen && !dialog.value?.open) dialog.value?.showModal()
+  else if (!isOpen && dialog.value?.open) dialog.value.close()
+})
+</script>
+
+<style lang="scss">
+@reference "../assets/main.css";
+
+.confirm-modal {
+  @apply m-auto w-full max-w-sm rounded-lg border border-gl-gray bg-white p-0 text-gl-darkblue shadow-lg;
+  @apply dark:border-gl-deep-blue dark:bg-gl-darkblue dark:text-white;
+
+  &::backdrop {
+    @apply bg-black/50;
+  }
+
+  &__panel {
+    @apply p-6;
+  }
+
+  &__title {
+    @apply text-lg font-bold mb-3;
+  }
+
+  &__message {
+    @apply text-sm mb-4;
+  }
+
+  &__actions {
+    @apply grid gap-2;
+  }
+
+  &__button {
+    @apply w-full py-3 px-4 rounded border border-gl-gray font-medium transition duration-200 ease-in-out;
+    @apply dark:bg-gl-deep-blue/50 dark:border-gl-deep-blue;
+
+    &:hover, &:focus {
+      @apply bg-blue-50 border-blue-300 ring-2 ring-blue-300/50 outline-none;
+      @apply dark:bg-gl-deep-blue dark:border-gl-darkblue dark:ring-gl-darkblue;
+    }
+
+    &--primary {
+      @apply bg-gl-lightgreen border-gl-green text-gray-800;
+      @apply dark:bg-gl-green dark:border-gl-lightgreen dark:text-gray-200;
+
+      &:hover, &:focus {
+        @apply bg-green-300 ring-4 ring-gl-lightgreen/50 border-gl-green;
+        @apply dark:bg-green-800 dark:ring-gl-green/30 dark:border-gl-lightgreen;
+      }
+    }
+
+    &--destructive {
+      @apply bg-red-600 border-red-700 text-white;
+      @apply dark:bg-red-700 dark:border-red-800 dark:text-white;
+
+      &:hover, &:focus {
+        @apply bg-red-700 ring-4 ring-red-400/50 border-red-700;
+        @apply dark:bg-red-800 dark:ring-red-500/30 dark:border-red-800;
+      }
+    }
+  }
+}
+</style>

--- a/src/views/Lists.vue
+++ b/src/views/Lists.vue
@@ -1,36 +1,56 @@
 <template>
-  <div v-if="lists.length" class="lists">
-    <div v-for="list in lists" :key="list.id" class="list__container">
-      <router-link class="list"
-                   :to="{ name: 'List', params: { id: list.id } }">
-        <span>{{ list.n }}</span>
-        <button :aria-label="`Delete your ${list.n} list`"
-                @click.prevent="deleteList(list)"
-                class="list__icon--delete">
-          <font-awesome-icon icon="times-circle"/>
-        </button>
-      </router-link>
+  <div>
+    <div v-if="lists.length" class="lists">
+      <div v-for="list in lists" :key="list.id" class="list__container">
+        <router-link class="list"
+                     :to="{ name: 'List', params: { id: list.id } }">
+          <span>{{ list.n }}</span>
+          <button :aria-label="`Delete your ${list.n} list`"
+                  @click.prevent="requestDelete(list)"
+                  class="list__icon--delete">
+            <font-awesome-icon icon="times-circle"/>
+          </button>
+        </router-link>
+      </div>
     </div>
-  </div>
-  <div v-else class="no-lists">
-    <span>You have no lists, </span>
-    <router-link :to="{ name: 'New' }" class="no-lists__link">create one</router-link>
-    <span>!</span>
+    <div v-else class="no-lists">
+      <span>You have no lists, </span>
+      <router-link :to="{ name: 'New' }" class="no-lists__link">create one</router-link>
+      <span>!</span>
+    </div>
+
+    <ConfirmModal v-if="pendingDelete"
+                  :open="!!pendingDelete"
+                  title="Delete list?"
+                  :message="`Are you sure you want to delete your ${pendingDelete.n} list?`"
+                  variant="destructive"
+                  confirm-label="Delete"
+                  @confirm="confirmDelete"
+                  @update:open="onModalOpenChange"/>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useListsStore } from '@/stores/lists'
+import ConfirmModal from '@/components/ConfirmModal.vue'
 import type List from '@/classes/List'
 
 const listsStore = useListsStore()
 const lists = computed(() => listsStore.lists)
+const pendingDelete = ref<List | null>(null)
 
-function deleteList (list: List): void {
-  if (confirm('Are you sure you want to delete your ' + list.n + ' list?')) {
-    listsStore.deleteList(list.id)
-  }
+function requestDelete (list: List): void {
+  pendingDelete.value = list
+}
+
+function confirmDelete (): void {
+  if (pendingDelete.value) listsStore.deleteList(pendingDelete.value.id)
+  pendingDelete.value = null
+}
+
+function onModalOpenChange (value: boolean): void {
+  if (!value) pendingDelete.value = null
 }
 
 onMounted(() => {

--- a/tests/unit/components/ConfirmModal.spec.js
+++ b/tests/unit/components/ConfirmModal.spec.js
@@ -1,0 +1,123 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import ConfirmModal from '@/components/ConfirmModal.vue'
+
+const baseProps = {
+  open: false,
+  title: 'Delete list?',
+  message: 'Are you sure you want to delete your Costco list?'
+}
+
+const mountModal = (props = {}) => mount(ConfirmModal, {
+  props: { ...baseProps, ...props }
+})
+
+describe('ConfirmModal', () => {
+  beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn(function () { this.open = true })
+    HTMLDialogElement.prototype.close = vi.fn(function () {
+      this.open = false
+      this.dispatchEvent(new Event('close'))
+    })
+  })
+
+  it('renders title, message, and default labels', () => {
+    const wrapper = mountModal()
+    expect(wrapper.text()).toContain('Delete list?')
+    expect(wrapper.text()).toContain('Are you sure you want to delete your Costco list?')
+    const labels = wrapper.findAll('button').map(b => b.text())
+    expect(labels).toEqual(['Cancel', 'Confirm'])
+  })
+
+  it('respects custom confirm/cancel labels', () => {
+    const wrapper = mountModal({ confirmLabel: 'Delete', cancelLabel: 'Keep' })
+    const labels = wrapper.findAll('button').map(b => b.text())
+    expect(labels).toEqual(['Keep', 'Delete'])
+  })
+
+  it('renders Cancel before Confirm in DOM order so Cancel autofocuses', () => {
+    const wrapper = mountModal()
+    const buttons = wrapper.findAll('button')
+    expect(buttons[0].text()).toBe('Cancel')
+    expect(buttons[1].text()).toBe('Confirm')
+  })
+
+  it('applies primary variant by default', () => {
+    const wrapper = mountModal({ confirmLabel: 'Confirm' })
+    const confirmBtn = wrapper.findAll('button').find(b => b.text() === 'Confirm')
+    expect(confirmBtn.classes()).toContain('confirm-modal__button--primary')
+    expect(confirmBtn.classes()).not.toContain('confirm-modal__button--destructive')
+  })
+
+  it('applies destructive variant class when variant=destructive', () => {
+    const wrapper = mountModal({ variant: 'destructive', confirmLabel: 'Delete' })
+    const confirmBtn = wrapper.findAll('button').find(b => b.text() === 'Delete')
+    expect(confirmBtn.classes()).toContain('confirm-modal__button--destructive')
+    expect(confirmBtn.classes()).not.toContain('confirm-modal__button--primary')
+  })
+
+  it('emits confirm + update:open=false when Confirm is clicked', async () => {
+    const wrapper = mountModal({ open: true })
+    await wrapper.findAll('button').find(b => b.text() === 'Confirm').trigger('click')
+    expect(wrapper.emitted('confirm')).toBeTruthy()
+    expect(wrapper.emitted('update:open')).toEqual([[false]])
+    expect(wrapper.emitted('cancel')).toBeFalsy()
+  })
+
+  it('emits cancel + update:open=false when Cancel is clicked', async () => {
+    const wrapper = mountModal({ open: true })
+    await wrapper.findAll('button').find(b => b.text() === 'Cancel').trigger('click')
+    expect(wrapper.emitted('cancel')).toBeTruthy()
+    expect(wrapper.emitted('update:open')).toEqual([[false]])
+    expect(wrapper.emitted('confirm')).toBeFalsy()
+  })
+
+  it('cancels when backdrop is clicked (target is dialog itself)', async () => {
+    const wrapper = mountModal({ open: true })
+    const dialogEl = wrapper.find('dialog').element
+    dialogEl.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('cancel')).toBeTruthy()
+  })
+
+  it('does not cancel when click target is inside the panel', async () => {
+    const wrapper = mountModal({ open: true })
+    await wrapper.find('.confirm-modal__panel').trigger('click')
+    expect(wrapper.emitted('cancel')).toBeFalsy()
+  })
+
+  it('cancels when the dialog fires native close (e.g. ESC)', async () => {
+    const wrapper = mountModal({ open: true })
+    wrapper.find('dialog').element.dispatchEvent(new Event('close'))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('cancel')).toBeTruthy()
+    expect(wrapper.emitted('update:open')).toEqual([[false]])
+  })
+
+  it('calls showModal on mount when open=true', () => {
+    mountModal({ open: true })
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled()
+  })
+
+  it('calls showModal when open transitions to true', async () => {
+    const wrapper = mountModal({ open: false })
+    expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled()
+    await wrapper.setProps({ open: true })
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled()
+  })
+
+  it('calls close when open transitions to false', async () => {
+    const wrapper = mountModal({ open: true })
+    await wrapper.setProps({ open: false })
+    expect(HTMLDialogElement.prototype.close).toHaveBeenCalled()
+  })
+
+  it('wires aria-labelledby to title and aria-describedby to message', () => {
+    const wrapper = mountModal()
+    const dialogEl = wrapper.find('dialog')
+    const labelledby = dialogEl.attributes('aria-labelledby')
+    const describedby = dialogEl.attributes('aria-describedby')
+    expect(wrapper.find(`#${labelledby}`).text()).toBe('Delete list?')
+    expect(wrapper.find(`#${describedby}`).text()).toBe('Are you sure you want to delete your Costco list?')
+  })
+})

--- a/tests/unit/views/Lists.spec.js
+++ b/tests/unit/views/Lists.spec.js
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createTestingPinia } from '@pinia/testing'
 import { useListsStore } from '@/stores/lists'
 import Lists from '@/views/Lists.vue'
@@ -8,61 +9,62 @@ const stubs = {
   FontAwesomeIcon: { template: '<span />' }
 }
 
+const mountLists = (lists) => mount(Lists, {
+  global: {
+    plugins: [createTestingPinia({ initialState: { lists: { lists } } })],
+    stubs
+  }
+})
+
 describe('Lists.vue', () => {
-  it('shows empty-state message when there are no lists', () => {
-    const wrapper = mount(Lists, {
-      global: {
-        plugins: [createTestingPinia({ initialState: { lists: { lists: [] } } })],
-        stubs
-      }
+  beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn(function () { this.open = true })
+    HTMLDialogElement.prototype.close = vi.fn(function () {
+      this.open = false
+      this.dispatchEvent(new Event('close'))
     })
+  })
+
+  it('shows empty-state message when there are no lists', () => {
+    const wrapper = mountLists([])
     expect(wrapper.text()).toContain('You have no lists')
   })
 
   it('renders one row per list', () => {
-    const wrapper = mount(Lists, {
-      global: {
-        plugins: [createTestingPinia({
-          initialState: {
-            lists: { lists: [{ id: 'a', n: 'Fruit', i: [] }, { id: 'b', n: 'Veg', i: [] }] }
-          }
-        })],
-        stubs
-      }
-    })
+    const wrapper = mountLists([{ id: 'a', n: 'Fruit', i: [] }, { id: 'b', n: 'Veg', i: [] }])
     expect(wrapper.text()).toContain('Fruit')
     expect(wrapper.text()).toContain('Veg')
   })
 
-  it('calls deleteList when confirm is accepted', async () => {
-    vi.stubGlobal('confirm', () => true)
-    const wrapper = mount(Lists, {
-      global: {
-        plugins: [createTestingPinia({
-          initialState: { lists: { lists: [{ id: 'a1', n: 'Fruit', i: [] }] } }
-        })],
-        stubs
-      }
-    })
-    const store = useListsStore()
-    await wrapper.find('button').trigger('click')
-    expect(store.deleteList).toHaveBeenCalledWith('a1')
-    vi.unstubAllGlobals()
+  it('does not show the confirm modal until a delete is requested', () => {
+    const wrapper = mountLists([{ id: 'a1', n: 'Fruit', i: [] }])
+    expect(wrapper.find('.confirm-modal').exists()).toBe(false)
   })
 
-  it('does not call deleteList when confirm is cancelled', async () => {
-    vi.stubGlobal('confirm', () => false)
-    const wrapper = mount(Lists, {
-      global: {
-        plugins: [createTestingPinia({
-          initialState: { lists: { lists: [{ id: 'a1', n: 'Fruit', i: [] }] } }
-        })],
-        stubs
-      }
-    })
+  it('opens the confirm modal with the list name when delete is clicked', async () => {
+    const wrapper = mountLists([{ id: 'a1', n: 'Fruit', i: [] }])
+    await wrapper.find('.list__icon--delete').trigger('click')
+    const modal = wrapper.find('.confirm-modal')
+    expect(modal.exists()).toBe(true)
+    expect(modal.text()).toContain('Fruit')
+    expect(modal.text()).toContain('Delete list?')
+  })
+
+  it('calls deleteList when the modal Delete button is clicked', async () => {
+    const wrapper = mountLists([{ id: 'a1', n: 'Fruit', i: [] }])
     const store = useListsStore()
-    await wrapper.find('button').trigger('click')
+    await wrapper.find('.list__icon--delete').trigger('click')
+    await wrapper.findAll('button').find(b => b.text() === 'Delete').trigger('click')
+    expect(store.deleteList).toHaveBeenCalledWith('a1')
+    expect(wrapper.find('.confirm-modal').exists()).toBe(false)
+  })
+
+  it('does not call deleteList when the modal Cancel button is clicked', async () => {
+    const wrapper = mountLists([{ id: 'a1', n: 'Fruit', i: [] }])
+    const store = useListsStore()
+    await wrapper.find('.list__icon--delete').trigger('click')
+    await wrapper.findAll('button').find(b => b.text() === 'Cancel').trigger('click')
     expect(store.deleteList).not.toHaveBeenCalled()
-    vi.unstubAllGlobals()
+    expect(wrapper.find('.confirm-modal').exists()).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- Replaces `confirm()` for list deletion in `Lists.vue` with a new reusable `ConfirmModal` component (`primary` | `destructive` variants), matching the chrome of `ImportModal` / `ShareSheet`
- Destructive variant introduces a red filled button (`bg-red-600` / dark `bg-red-700`); button DOM order puts Cancel first so it autofocuses on open
- 14 new unit tests for `ConfirmModal`; `Lists.spec.js` rewritten to drive the modal instead of stubbing `globalThis.confirm`

Closes #21

## Notes
- Item delete remains unchanged (soft-delete + tombstone, recoverable in spirit) — out of scope per issue
- `Lists.vue` template wrapped in a single root `<div>` so it stays compatible with `<Transition mode="out-in">` in `App.vue`

## Test plan
- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run test:unit` — 88/88 (10 files)
- [x] `npm run test:coverage` — `ConfirmModal.vue` 100% lines, `Lists.vue` 100% lines
- [x] `npm run test:e2e` — 9/9 (Playwright + axe)