### PR TITLE
feat(sync): M3 — revoke/delete + toasts + tombstone GC

### DIFF
--- a/docs/plan-live-sync.md
+++ b/docs/plan-live-sync.md
@@ -1,6 +1,6 @@
 # Live Sync MVP — Implementation Plan
 
-**Status:** Drafted 2026-05-08. Not yet started.
+**Status:** M1 complete 2026-05-08. M2 complete 2026-05-08. M3 complete 2026-05-09.
 **Replaces:** Existing QR snapshot share (`src/utils/share.ts`, `src/components/ImportModal.vue`, pako encoding). Those go away in M4.
 
 ## 1. Goal
@@ -288,15 +288,11 @@ Editors don't see this panel.
 
 These were flagged during planning and should be re-resolved before M3:
 
-### 7.1 List-level mutation details (Q9 revisit)
+### 7.1 List-level mutation details (Q9 — resolved in M3)
 
-Specifically the tombstone retention strategy and whether list-level fields beyond `name` (e.g., a hypothetical `archived` flag) are in scope. Current plan assumes:
-
-- Tombstones retained forever in MVP. GC deferred until a list demonstrably crosses a size threshold.
+- Tombstones auto-GC'd after 30 days on write (`DELETE FROM items WHERE list_id=? AND d=1 AND u<?`). No cron needed.
 - Hard delete on owner action; recipients learn via 404 next poll.
-- 401 vs 404 status differentiation for "revoked" vs "deleted/missing."
-
-Revisit before M3.
+- 401 → "Access revoked" toast + local removal. 404 → "List deleted" toast + local removal.
 
 ### 7.2 Token reuse semantics edge cases
 

--- a/functions/api/_shared/handlers.ts
+++ b/functions/api/_shared/handlers.ts
@@ -234,26 +234,9 @@ export async function handleRevokeToken (
     return Response.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  let body: { tokenHash?: unknown }
-  try {
-    body = await request.json() as typeof body
-  } catch {
-    return Response.json({ error: 'Invalid JSON' }, { status: 400 })
-  }
-
-  if (typeof body.tokenHash !== 'string') {
-    return Response.json({ error: 'tokenHash required' }, { status: 400 })
-  }
-
-  const authHeader = request.headers.get('Authorization')!
-  const requesterHash = await hashToken(authHeader.slice(7))
-  if (requesterHash === body.tokenHash) {
-    return Response.json({ error: 'Cannot revoke own token' }, { status: 400 })
-  }
-
   await db.prepare(
-    'UPDATE list_tokens SET revoked_at = ? WHERE token_hash = ? AND list_id = ?'
-  ).bind(Date.now(), body.tokenHash, listId).run()
+    'UPDATE list_tokens SET revoked_at = ? WHERE list_id = ? AND role = ?'
+  ).bind(Date.now(), listId, 'editor').run()
 
   return Response.json({})
 }

--- a/functions/api/_shared/handlers.ts
+++ b/functions/api/_shared/handlers.ts
@@ -2,6 +2,8 @@ import type { ItemRow, ListRow, TokenRow } from './types'
 import { generateUlid, generateToken } from './ulid'
 import { hashToken, authenticate } from './auth'
 
+const TOMBSTONE_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
 export async function handleUpsertItem (
   db: D1Database,
   request: Request,
@@ -46,6 +48,7 @@ export async function handleUpsertItem (
        SET n=excluded.n, q=excluded.q, c=excluded.c, u=excluded.u, d=excluded.d`
     ).bind(listId, itemId, incoming.n, incoming.q, incoming.c, incoming.u, incoming.d),
     db.prepare('UPDATE lists SET version = version + 1 WHERE id = ?').bind(listId),
+    db.prepare('DELETE FROM items WHERE list_id = ? AND d = 1 AND u < ?').bind(listId, Date.now() - TOMBSTONE_TTL_MS),
   ])
 
   return Response.json({ item: incoming })
@@ -196,4 +199,81 @@ export async function handleJoin (
     version: list.version,
     items,
   })
+}
+
+export async function handleMintToken (
+  db: D1Database,
+  request: Request,
+  listId: string
+): Promise<Response> {
+  const auth = await authenticate(db, request, listId)
+  if (auth instanceof Response) return auth
+  if ((auth as TokenRow).role !== 'owner') {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const authToken = generateToken()
+  const tokenHash = await hashToken(authToken)
+  const now = Date.now()
+
+  await db.prepare(
+    'INSERT INTO list_tokens (token_hash, list_id, role, created_at) VALUES (?, ?, ?, ?)'
+  ).bind(tokenHash, listId, 'editor', now).run()
+
+  return Response.json({ token: authToken })
+}
+
+export async function handleRevokeToken (
+  db: D1Database,
+  request: Request,
+  listId: string
+): Promise<Response> {
+  const auth = await authenticate(db, request, listId)
+  if (auth instanceof Response) return auth
+  if ((auth as TokenRow).role !== 'owner') {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let body: { tokenHash?: unknown }
+  try {
+    body = await request.json() as typeof body
+  } catch {
+    return Response.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  if (typeof body.tokenHash !== 'string') {
+    return Response.json({ error: 'tokenHash required' }, { status: 400 })
+  }
+
+  const authHeader = request.headers.get('Authorization')!
+  const requesterHash = await hashToken(authHeader.slice(7))
+  if (requesterHash === body.tokenHash) {
+    return Response.json({ error: 'Cannot revoke own token' }, { status: 400 })
+  }
+
+  await db.prepare(
+    'UPDATE list_tokens SET revoked_at = ? WHERE token_hash = ? AND list_id = ?'
+  ).bind(Date.now(), body.tokenHash, listId).run()
+
+  return Response.json({})
+}
+
+export async function handleDeleteList (
+  db: D1Database,
+  request: Request,
+  listId: string
+): Promise<Response> {
+  const auth = await authenticate(db, request, listId)
+  if (auth instanceof Response) return auth
+  if ((auth as TokenRow).role !== 'owner') {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  await db.batch([
+    db.prepare('DELETE FROM items WHERE list_id = ?').bind(listId),
+    db.prepare('DELETE FROM list_tokens WHERE list_id = ?').bind(listId),
+    db.prepare('DELETE FROM lists WHERE id = ?').bind(listId),
+  ])
+
+  return Response.json({})
 }

--- a/functions/api/_shared/handlers.ts
+++ b/functions/api/_shared/handlers.ts
@@ -2,7 +2,7 @@ import type { ItemRow, ListRow, TokenRow } from './types'
 import { generateUlid, generateToken } from './ulid'
 import { hashToken, authenticate } from './auth'
 
-const TOMBSTONE_TTL_MS = 30 * 24 * 60 * 60 * 1000
+const TOMBSTONE_TTL_MS = 90 * 24 * 60 * 60 * 1000
 
 export async function handleUpsertItem (
   db: D1Database,

--- a/functions/api/lists/[id]/index.ts
+++ b/functions/api/lists/[id]/index.ts
@@ -1,9 +1,12 @@
 import type { PagesFunction } from '@cloudflare/workers-types'
 import type { Env } from '../../_shared/types'
-import { handlePoll, handlePatchList } from '../../_shared/handlers'
+import { handlePoll, handlePatchList, handleDeleteList } from '../../_shared/handlers'
 
 export const onRequestGet: PagesFunction<Env> = ({ request, env, params }) =>
   handlePoll(env.DB, request, params.id as string)
 
 export const onRequestPatch: PagesFunction<Env> = ({ request, env, params }) =>
   handlePatchList(env.DB, request, params.id as string)
+
+export const onRequestDelete: PagesFunction<Env> = ({ request, env, params }) =>
+  handleDeleteList(env.DB, request, params.id as string)

--- a/functions/api/lists/[id]/tokens/index.ts
+++ b/functions/api/lists/[id]/tokens/index.ts
@@ -1,0 +1,6 @@
+import type { PagesFunction } from '@cloudflare/workers-types'
+import type { Env } from '../../../_shared/types'
+import { handleMintToken } from '../../../_shared/handlers'
+
+export const onRequestPost: PagesFunction<Env> = ({ request, env, params }) =>
+  handleMintToken(env.DB, request, params.id as string)

--- a/functions/api/lists/[id]/tokens/revoke.ts
+++ b/functions/api/lists/[id]/tokens/revoke.ts
@@ -1,0 +1,6 @@
+import type { PagesFunction } from '@cloudflare/workers-types'
+import type { Env } from '../../../_shared/types'
+import { handleRevokeToken } from '../../../_shared/handlers'
+
+export const onRequestPost: PagesFunction<Env> = ({ request, env, params }) =>
+  handleRevokeToken(env.DB, request, params.id as string)

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,7 @@
                   @merge="onMerge"
                   @copy="onCopy"
                   @cancel="onCancel"/>
+    <toast-container/>
     <div aria-live="polite" aria-atomic="true" class="sr-only">{{ liveMessage }}</div>
   </div>
 </template>
@@ -26,6 +27,7 @@ import { ref, shallowRef, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import AppHeader from '@/components/AppHeader.vue'
 import ImportModal from '@/components/ImportModal.vue'
+import ToastContainer from '@/components/ToastContainer.vue'
 import { useListsStore } from '@/stores/lists'
 import { useLiveRegion } from '@/composables/useLiveRegion'
 import type List from '@/classes/List'

--- a/src/components/ShareSheet.vue
+++ b/src/components/ShareSheet.vue
@@ -16,34 +16,15 @@
         </button>
       </div>
 
-      <div v-if="isOwner" class="share-sheet__tabs" role="tablist">
-        <button role="tab"
-                :aria-selected="activeTab === 'share'"
-                class="share-sheet__tab"
-                :class="{ 'share-sheet__tab--active': activeTab === 'share' }"
-                @click="activeTab = 'share'">
-          Share
-        </button>
-        <button role="tab"
-                :aria-selected="activeTab === 'manage'"
-                class="share-sheet__tab"
-                :class="{ 'share-sheet__tab--active': activeTab === 'manage' }"
-                @click="activeTab = 'manage'">
-          Manage
-        </button>
+      <div v-if="state === 'loading'" class="share-sheet__loading">Setting up…</div>
+
+      <div v-else-if="state === 'error'" class="share-sheet__error">
+        Could not create shared list. Check your connection and try again.
       </div>
 
-      <!-- Share tab -->
-      <template v-if="activeTab === 'share'">
-        <div v-if="state === 'loading'" class="share-sheet__loading">Setting up shared list…</div>
-
-        <div v-else-if="state === 'error'" class="share-sheet__too-large">
-          Could not create shared list. Check your connection and try again.
-        </div>
-
-        <div v-else-if="state === 'ready'" class="share-sheet__qr" v-html="qrSvg"/>
-
-        <div v-if="state === 'ready'" class="share-sheet__actions">
+      <template v-else-if="state === 'sharing'">
+        <div class="share-sheet__qr" v-html="qrSvg"/>
+        <div class="share-sheet__actions">
           <button v-if="canWebShare"
                   type="button"
                   class="share-sheet__button share-sheet__button--primary"
@@ -55,122 +36,44 @@
                   @click="onCopy">
             {{ copied ? 'Copied!' : 'Copy link' }}
           </button>
+          <button v-if="isOwner"
+                  type="button"
+                  class="share-sheet__button share-sheet__button--secondary"
+                  :disabled="stopping"
+                  @click="onStopSharing">
+            {{ stopping ? 'Revoking…' : 'Stop sharing' }}
+          </button>
         </div>
       </template>
 
-      <!-- Manage tab (owner only) -->
-      <template v-else-if="activeTab === 'manage'">
-        <div class="share-sheet__manage">
-
-          <!-- Original join link -->
-          <div class="share-sheet__section">
-            <h3 class="share-sheet__section-title">Original join link</h3>
-            <p class="share-sheet__section-desc">Multi-use — anyone with this link can join as an editor.</p>
-            <button type="button"
-                    class="share-sheet__button"
-                    @click="copyOriginalLink">
-              {{ copiedOriginal ? 'Copied!' : 'Copy original link' }}
-            </button>
-          </div>
-
-          <!-- Minted editor links -->
-          <div class="share-sheet__section">
-            <h3 class="share-sheet__section-title">
-              Editor links
-              <span v-if="editorTokens.length" class="share-sheet__count">({{ editorTokens.length }})</span>
-            </h3>
-
-            <div v-if="editorTokens.length === 0" class="share-sheet__empty">
-              No individual editor links yet.
-            </div>
-
-            <ul v-else class="share-sheet__token-list">
-              <li v-for="et in editorTokens" :key="et.hash" class="share-sheet__token-item">
-                <span class="share-sheet__token-label">{{ et.label }}</span>
-                <button type="button"
-                        class="share-sheet__token-action"
-                        :aria-label="`Copy link for ${et.label}`"
-                        @click="copyEditorLink(et)">
-                  <font-awesome-icon icon="copy"/>
-                </button>
-                <button type="button"
-                        class="share-sheet__token-action share-sheet__token-action--revoke"
-                        :aria-label="`Revoke link for ${et.label}`"
-                        :disabled="revoking === et.hash"
-                        @click="confirmRevoke(et)">
-                  <font-awesome-icon :icon="revoking === et.hash ? 'spinner' : 'ban'"/>
-                </button>
-              </li>
-            </ul>
-
-            <!-- Mint flow -->
-            <div v-if="mintState === 'idle'" class="share-sheet__mint-trigger">
-              <button type="button"
-                      class="share-sheet__button"
-                      @click="mintState = 'entering-label'">
-                + Add editor link
-              </button>
-            </div>
-
-            <div v-else-if="mintState === 'entering-label'" class="share-sheet__mint-form">
-              <label for="mint-label" class="share-sheet__mint-label-text">Label (e.g. "Sarah's phone")</label>
-              <input id="mint-label"
-                     v-model="mintLabel"
-                     class="share-sheet__mint-input"
-                     type="text"
-                     placeholder="Device or person name"
-                     @keydown.enter.prevent="generateEditorLink"
-                     @keydown.escape="mintState = 'idle'"/>
-              <div class="share-sheet__mint-actions">
-                <button type="button" class="share-sheet__button" @click="mintState = 'idle'">Cancel</button>
-                <button type="button"
-                        class="share-sheet__button share-sheet__button--primary"
-                        :disabled="!mintLabel.trim()"
-                        @click="generateEditorLink">
-                  Generate
-                </button>
-              </div>
-            </div>
-
-            <div v-else-if="mintState === 'generating'" class="share-sheet__loading">
-              Generating link…
-            </div>
-
-            <div v-else-if="mintState === 'showing-link'" class="share-sheet__mint-result">
-              <p class="share-sheet__mint-result-title">Link for "{{ mintLabel }}"</p>
-              <div class="share-sheet__qr" v-html="mintQrSvg"/>
-              <button type="button"
-                      class="share-sheet__button"
-                      @click="copyMintedLink">
-                {{ copiedMinted ? 'Copied!' : 'Copy link' }}
-              </button>
-              <button type="button"
-                      class="share-sheet__button share-sheet__button--primary"
-                      @click="doneMinting">
-                Done
-              </button>
-            </div>
-          </div>
-
-          <!-- Delete list -->
-          <div class="share-sheet__section share-sheet__section--danger">
-            <button type="button"
-                    class="share-sheet__button share-sheet__button--destructive"
-                    @click="confirmDelete">
-              Delete shared list…
-            </button>
-          </div>
+      <template v-else-if="state === 'not-sharing'">
+        <p class="share-sheet__hint">Sharing is off. Enable it to let others join with a link.</p>
+        <div class="share-sheet__actions">
+          <button type="button"
+                  class="share-sheet__button share-sheet__button--primary"
+                  :disabled="enabling"
+                  @click="onEnableSharing">
+            {{ enabling ? 'Generating…' : 'Enable sharing' }}
+          </button>
         </div>
       </template>
+
+      <div v-if="isOwner && state !== 'loading'" class="share-sheet__danger-zone">
+        <button type="button"
+                class="share-sheet__button share-sheet__button--destructive"
+                @click="confirmDelete">
+          Delete shared list…
+        </button>
+      </div>
     </div>
   </dialog>
 
   <confirm-modal v-model:open="confirmOpen"
-                 :title="confirmTitle"
-                 :message="confirmMessage"
+                 title="Delete shared list"
+                 :message="`Delete &quot;${list.n}&quot;? All devices will lose access and the list will be removed everywhere.`"
                  variant="destructive"
-                 :confirm-label="confirmLabel"
-                 @confirm="onConfirmed"/>
+                 confirm-label="Delete"
+                 @confirm="onDeleteConfirmed"/>
 </template>
 
 <script setup lang="ts">
@@ -179,7 +82,6 @@ import type List from '@/classes/List'
 import { useLiveRegion } from '@/composables/useLiveRegion'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import * as sync from '@/sync'
-import type { EditorToken } from '@/sync/types'
 
 const props = defineProps<{ open: boolean; list: List }>()
 const emit = defineEmits<{
@@ -189,40 +91,20 @@ const emit = defineEmits<{
 }>()
 
 const dialog = ref<HTMLDialogElement | null>(null)
-const state = ref<'loading' | 'ready' | 'error'>('loading')
-const activeTab = ref<'share' | 'manage'>('share')
+const state = ref<'loading' | 'sharing' | 'not-sharing' | 'error'>('loading')
 const qrSvg = ref('')
 const joinUrl = ref('')
 const copied = ref(false)
-const copiedOriginal = ref(false)
+const stopping = ref(false)
+const enabling = ref(false)
+const confirmOpen = ref(false)
 const canWebShare = ref(typeof navigator !== 'undefined' && typeof navigator.share === 'function')
 const { announce } = useLiveRegion()
 
-// Manage tab state
-const editorTokens = computed<EditorToken[]>(() =>
-  sync.getMeta(props.list.id)?.editorTokens ?? []
-)
-const isOwner = computed(() => sync.getMeta(props.list.id)?.role === 'owner')
-const revoking = ref<string | null>(null)
-
-// Mint flow
-const mintState = ref<'idle' | 'entering-label' | 'generating' | 'showing-link'>('idle')
-const mintLabel = ref('')
-const mintQrSvg = ref('')
-const mintedJoinUrl = ref('')
-const copiedMinted = ref(false)
-
-// Confirm modal
-const confirmOpen = ref(false)
-const confirmTitle = ref('')
-const confirmMessage = ref('')
-const confirmLabel = ref('Confirm')
-let pendingConfirmAction: (() => Promise<void>) | null = null
-
 let copyTimer: ReturnType<typeof setTimeout> | null = null
-let copyOriginalTimer: ReturnType<typeof setTimeout> | null = null
-let copyMintedTimer: ReturnType<typeof setTimeout> | null = null
 let provisionedListId: string | null = null
+
+const isOwner = computed(() => sync.getMeta(props.list.id)?.role === 'owner')
 
 async function build () {
   state.value = 'loading'
@@ -232,28 +114,71 @@ async function build () {
 
   const capturedList = props.list
 
-  if (sync.isSynced(capturedList.id)) {
-    const meta = sync.getMeta(capturedList.id)!
-    joinUrl.value = `${window.location.origin}/#join=${capturedList.id}.${meta.authToken}`
-    provisionedListId = null
-  } else {
+  if (!sync.isSynced(capturedList.id)) {
     const result = await sync.provision(capturedList)
     if (!result) {
       state.value = 'error'
       return
     }
-    joinUrl.value = result.joinUrl
     provisionedListId = result.listId
+    // Auto-enable sharing immediately after provisioning
+    const url = await sync.enableSharing(capturedList.id)
+    if (url) await showShareLink(url)
+    else state.value = 'error'
+    return
   }
 
+  provisionedListId = null
+  const meta = sync.getMeta(capturedList.id)
+
+  if (meta?.role === 'owner') {
+    if (meta.shareToken) {
+      await showShareLink(`${window.location.origin}/#join=${capturedList.id}.${meta.shareToken}`)
+    } else {
+      state.value = 'not-sharing'
+    }
+  } else {
+    // Editor: show their own join link
+    const token = meta?.authToken ?? ''
+    await showShareLink(`${window.location.origin}/#join=${capturedList.id}.${token}`)
+  }
+}
+
+async function showShareLink (url: string) {
+  joinUrl.value = url
   const qrcodeMod = await import('qrcode')
   const QRCode = qrcodeMod.default ?? qrcodeMod
-  qrSvg.value = await QRCode.toString(joinUrl.value, {
+  qrSvg.value = await QRCode.toString(url, {
     type: 'svg',
     margin: 1,
     color: { dark: '#111827', light: '#ffffff' }
   })
-  state.value = 'ready'
+  state.value = 'sharing'
+}
+
+async function onEnableSharing () {
+  enabling.value = true
+  const url = await sync.enableSharing(props.list.id)
+  enabling.value = false
+  if (!url) {
+    announce('Could not enable sharing — check your connection')
+    return
+  }
+  await showShareLink(url)
+}
+
+async function onStopSharing () {
+  stopping.value = true
+  const ok = await sync.disableSharing(props.list.id)
+  stopping.value = false
+  if (!ok) {
+    announce('Could not stop sharing — check your connection')
+    return
+  }
+  qrSvg.value = ''
+  joinUrl.value = ''
+  state.value = 'not-sharing'
+  announce('Sharing stopped — existing links no longer work')
 }
 
 function close () {
@@ -266,10 +191,6 @@ function onClose () {
     provisionedListId = null
   }
   emit('update:open', false)
-  mintState.value = 'idle'
-  mintLabel.value = ''
-  mintQrSvg.value = ''
-  mintedJoinUrl.value = ''
 }
 
 function onBackdropClick (event: MouseEvent) {
@@ -302,109 +223,17 @@ async function onCopy () {
   }
 }
 
-async function copyOriginalLink () {
-  if (!joinUrl.value) return
-  try {
-    await navigator.clipboard.writeText(joinUrl.value)
-    copiedOriginal.value = true
-    announce('Original link copied to clipboard')
-    if (copyOriginalTimer) clearTimeout(copyOriginalTimer)
-    copyOriginalTimer = setTimeout(() => { copiedOriginal.value = false }, 2000)
-  } catch {
-    announce('Could not copy link')
-  }
-}
-
-async function copyEditorLink (et: EditorToken) {
-  const url = `${window.location.origin}/#join=${props.list.id}.${et.token}`
-  try {
-    await navigator.clipboard.writeText(url)
-    announce(`Link for ${et.label} copied`)
-  } catch {
-    announce('Could not copy link')
-  }
-}
-
-async function generateEditorLink () {
-  if (!mintLabel.value.trim()) return
-  mintState.value = 'generating'
-
-  const result = await sync.mintEditorToken(props.list.id, mintLabel.value.trim())
-  if (!result) {
-    mintState.value = 'idle'
-    announce('Could not generate editor link')
-    return
-  }
-
-  mintedJoinUrl.value = result.joinUrl
-  const qrcodeMod = await import('qrcode')
-  const QRCode = qrcodeMod.default ?? qrcodeMod
-  mintQrSvg.value = await QRCode.toString(result.joinUrl, {
-    type: 'svg',
-    margin: 1,
-    color: { dark: '#111827', light: '#ffffff' }
-  })
-  mintState.value = 'showing-link'
-}
-
-async function copyMintedLink () {
-  if (!mintedJoinUrl.value) return
-  try {
-    await navigator.clipboard.writeText(mintedJoinUrl.value)
-    copiedMinted.value = true
-    announce('Editor link copied to clipboard')
-    if (copyMintedTimer) clearTimeout(copyMintedTimer)
-    copyMintedTimer = setTimeout(() => { copiedMinted.value = false }, 2000)
-  } catch {
-    announce('Could not copy link')
-  }
-}
-
-function doneMinting () {
-  mintState.value = 'idle'
-  mintLabel.value = ''
-  mintQrSvg.value = ''
-  mintedJoinUrl.value = ''
-  copiedMinted.value = false
-}
-
-function confirmRevoke (et: EditorToken) {
-  confirmTitle.value = 'Revoke editor link'
-  confirmMessage.value = `Revoke access for "${et.label}"? Their link will stop working immediately.`
-  confirmLabel.value = 'Revoke'
-  pendingConfirmAction = async () => {
-    revoking.value = et.hash
-    const ok = await sync.revokeEditorToken(props.list.id, et.hash)
-    revoking.value = null
-    if (ok) {
-      announce(`Access for ${et.label} revoked`)
-    } else {
-      announce('Could not revoke — check your connection')
-    }
-  }
-  confirmOpen.value = true
-}
-
 function confirmDelete () {
-  confirmTitle.value = 'Delete shared list'
-  confirmMessage.value = `Delete "${props.list.n}"? All devices will lose access and the list will be removed everywhere.`
-  confirmLabel.value = 'Delete'
-  pendingConfirmAction = async () => {
-    const ok = await sync.deleteList(props.list.id)
-    if (ok) {
-      close()
-      emit('deleted')
-    } else {
-      announce('Could not delete — check your connection')
-    }
-  }
   confirmOpen.value = true
 }
 
-async function onConfirmed () {
-  if (pendingConfirmAction) {
-    await pendingConfirmAction()
-    pendingConfirmAction = null
+async function onDeleteConfirmed () {
+  const ok = await sync.deleteList(props.list.id)
+  if (ok) {
+    close()
+    emit('deleted')
+  } else {
+    announce('Could not delete — check your connection')
   }
 }
 
@@ -418,7 +247,6 @@ onMounted(async () => {
 watch(() => props.open, async (isOpen) => {
   if (isOpen) {
     if (!dialog.value?.open) dialog.value?.showModal()
-    activeTab.value = 'share'
     await build()
   } else if (dialog.value?.open) {
     dialog.value.close()
@@ -427,8 +255,6 @@ watch(() => props.open, async (isOpen) => {
 
 onUnmounted(() => {
   if (copyTimer) clearTimeout(copyTimer)
-  if (copyOriginalTimer) clearTimeout(copyOriginalTimer)
-  if (copyMintedTimer) clearTimeout(copyMintedTimer)
 })
 </script>
 
@@ -463,30 +289,17 @@ onUnmounted(() => {
     }
   }
 
-  &__tabs {
-    @apply flex border-b border-gl-gray mb-4;
-    @apply dark:border-gl-deep-blue;
-  }
-
-  &__tab {
-    @apply px-4 py-2 text-sm font-medium border-b-2 border-transparent -mb-px transition-colors duration-150;
-
-    &:hover {
-      @apply text-gl-blueberry;
-    }
-
-    &--active {
-      @apply border-gl-blueberry text-gl-blueberry;
-    }
-  }
-
   &__loading,
-  &__too-large {
+  &__hint {
     @apply text-center py-8 text-sm;
   }
 
-  &__too-large {
-    @apply bg-blue-50 rounded p-4 text-gl-darkblue;
+  &__hint {
+    @apply py-4 text-gray-500 dark:text-gray-400;
+  }
+
+  &__error {
+    @apply bg-blue-50 rounded p-4 text-gl-darkblue text-sm;
     @apply dark:bg-gl-deep-blue/50 dark:text-white;
   }
 
@@ -500,6 +313,11 @@ onUnmounted(() => {
 
   &__actions {
     @apply mt-4 grid gap-2;
+  }
+
+  &__danger-zone {
+    @apply mt-4 pt-4 border-t border-gl-gray;
+    @apply dark:border-gl-deep-blue;
   }
 
   &__button {
@@ -525,6 +343,10 @@ onUnmounted(() => {
       }
     }
 
+    &--secondary {
+      @apply text-gray-600 dark:text-gray-300;
+    }
+
     &--destructive {
       @apply bg-red-600 border-red-700 text-white;
       @apply dark:bg-red-700 dark:border-red-800;
@@ -534,100 +356,6 @@ onUnmounted(() => {
         @apply dark:bg-red-800 dark:ring-red-500/30 dark:border-red-800;
       }
     }
-  }
-
-  &__manage {
-    @apply flex flex-col gap-4;
-  }
-
-  &__section {
-    @apply flex flex-col gap-2;
-
-    &--danger {
-      @apply pt-2 border-t border-gl-gray;
-      @apply dark:border-gl-deep-blue;
-    }
-  }
-
-  &__section-title {
-    @apply text-sm font-semibold;
-  }
-
-  &__section-desc {
-    @apply text-xs text-gray-500 dark:text-gray-400;
-  }
-
-  &__count {
-    @apply font-normal text-gray-500 dark:text-gray-400;
-  }
-
-  &__empty {
-    @apply text-xs text-gray-400 italic;
-  }
-
-  &__token-list {
-    @apply flex flex-col gap-1 list-none p-0 m-0;
-  }
-
-  &__token-item {
-    @apply flex items-center gap-2 py-1;
-  }
-
-  &__token-label {
-    @apply text-sm flex-1 truncate;
-  }
-
-  &__token-action {
-    @apply text-base p-1 rounded transition-colors duration-150 min-w-[32px] min-h-[32px] flex items-center justify-center;
-
-    &:hover, &:focus {
-      @apply bg-blue-50 outline-none;
-      @apply dark:bg-gl-deep-blue;
-    }
-
-    &:disabled {
-      @apply opacity-50 cursor-not-allowed;
-    }
-
-    &--revoke {
-      &:hover, &:focus {
-        @apply bg-red-50 text-red-600;
-        @apply dark:bg-red-900/30;
-      }
-    }
-  }
-
-  &__mint-trigger {
-    @apply mt-1;
-  }
-
-  &__mint-form {
-    @apply flex flex-col gap-2 mt-1;
-  }
-
-  &__mint-label-text {
-    @apply text-xs font-medium;
-  }
-
-  &__mint-input {
-    @apply px-3 py-2 rounded border border-gl-gray text-sm outline-none transition duration-200;
-    @apply dark:border-gl-deep-blue dark:bg-gl-deep-blue/50 dark:text-gray-200;
-
-    &:focus {
-      @apply ring-2 ring-blue-300/50 border-blue-300;
-    }
-  }
-
-  &__mint-actions {
-    @apply grid grid-cols-2 gap-2;
-  }
-
-  &__mint-result {
-    @apply flex flex-col gap-2 mt-1;
-  }
-
-  &__mint-result-title {
-    @apply text-xs font-medium text-center;
   }
 }
 </style>

--- a/src/components/ShareSheet.vue
+++ b/src/components/ShareSheet.vue
@@ -16,52 +16,212 @@
         </button>
       </div>
 
-      <div v-if="state === 'loading'" class="share-sheet__loading">Setting up shared list…</div>
-
-      <div v-else-if="state === 'error'" class="share-sheet__too-large">
-        Could not create shared list. Check your connection and try again.
-      </div>
-
-      <div v-else-if="state === 'ready'" class="share-sheet__qr" v-html="qrSvg"/>
-
-      <div v-if="state === 'ready'" class="share-sheet__actions">
-        <button v-if="canWebShare"
-                type="button"
-                class="share-sheet__button share-sheet__button--primary"
-                @click="onShare">
-          Share link…
+      <div v-if="isOwner" class="share-sheet__tabs" role="tablist">
+        <button role="tab"
+                :aria-selected="activeTab === 'share'"
+                class="share-sheet__tab"
+                :class="{ 'share-sheet__tab--active': activeTab === 'share' }"
+                @click="activeTab = 'share'">
+          Share
         </button>
-        <button type="button"
-                class="share-sheet__button"
-                @click="onCopy">
-          {{ copied ? 'Copied!' : 'Copy link' }}
+        <button role="tab"
+                :aria-selected="activeTab === 'manage'"
+                class="share-sheet__tab"
+                :class="{ 'share-sheet__tab--active': activeTab === 'manage' }"
+                @click="activeTab = 'manage'">
+          Manage
         </button>
       </div>
+
+      <!-- Share tab -->
+      <template v-if="activeTab === 'share'">
+        <div v-if="state === 'loading'" class="share-sheet__loading">Setting up shared list…</div>
+
+        <div v-else-if="state === 'error'" class="share-sheet__too-large">
+          Could not create shared list. Check your connection and try again.
+        </div>
+
+        <div v-else-if="state === 'ready'" class="share-sheet__qr" v-html="qrSvg"/>
+
+        <div v-if="state === 'ready'" class="share-sheet__actions">
+          <button v-if="canWebShare"
+                  type="button"
+                  class="share-sheet__button share-sheet__button--primary"
+                  @click="onShare">
+            Share link…
+          </button>
+          <button type="button"
+                  class="share-sheet__button"
+                  @click="onCopy">
+            {{ copied ? 'Copied!' : 'Copy link' }}
+          </button>
+        </div>
+      </template>
+
+      <!-- Manage tab (owner only) -->
+      <template v-else-if="activeTab === 'manage'">
+        <div class="share-sheet__manage">
+
+          <!-- Original join link -->
+          <div class="share-sheet__section">
+            <h3 class="share-sheet__section-title">Original join link</h3>
+            <p class="share-sheet__section-desc">Multi-use — anyone with this link can join as an editor.</p>
+            <button type="button"
+                    class="share-sheet__button"
+                    @click="copyOriginalLink">
+              {{ copiedOriginal ? 'Copied!' : 'Copy original link' }}
+            </button>
+          </div>
+
+          <!-- Minted editor links -->
+          <div class="share-sheet__section">
+            <h3 class="share-sheet__section-title">
+              Editor links
+              <span v-if="editorTokens.length" class="share-sheet__count">({{ editorTokens.length }})</span>
+            </h3>
+
+            <div v-if="editorTokens.length === 0" class="share-sheet__empty">
+              No individual editor links yet.
+            </div>
+
+            <ul v-else class="share-sheet__token-list">
+              <li v-for="et in editorTokens" :key="et.hash" class="share-sheet__token-item">
+                <span class="share-sheet__token-label">{{ et.label }}</span>
+                <button type="button"
+                        class="share-sheet__token-action"
+                        :aria-label="`Copy link for ${et.label}`"
+                        @click="copyEditorLink(et)">
+                  <font-awesome-icon icon="copy"/>
+                </button>
+                <button type="button"
+                        class="share-sheet__token-action share-sheet__token-action--revoke"
+                        :aria-label="`Revoke link for ${et.label}`"
+                        :disabled="revoking === et.hash"
+                        @click="confirmRevoke(et)">
+                  <font-awesome-icon :icon="revoking === et.hash ? 'spinner' : 'ban'"/>
+                </button>
+              </li>
+            </ul>
+
+            <!-- Mint flow -->
+            <div v-if="mintState === 'idle'" class="share-sheet__mint-trigger">
+              <button type="button"
+                      class="share-sheet__button"
+                      @click="mintState = 'entering-label'">
+                + Add editor link
+              </button>
+            </div>
+
+            <div v-else-if="mintState === 'entering-label'" class="share-sheet__mint-form">
+              <label for="mint-label" class="share-sheet__mint-label-text">Label (e.g. "Sarah's phone")</label>
+              <input id="mint-label"
+                     v-model="mintLabel"
+                     class="share-sheet__mint-input"
+                     type="text"
+                     placeholder="Device or person name"
+                     @keydown.enter.prevent="generateEditorLink"
+                     @keydown.escape="mintState = 'idle'"/>
+              <div class="share-sheet__mint-actions">
+                <button type="button" class="share-sheet__button" @click="mintState = 'idle'">Cancel</button>
+                <button type="button"
+                        class="share-sheet__button share-sheet__button--primary"
+                        :disabled="!mintLabel.trim()"
+                        @click="generateEditorLink">
+                  Generate
+                </button>
+              </div>
+            </div>
+
+            <div v-else-if="mintState === 'generating'" class="share-sheet__loading">
+              Generating link…
+            </div>
+
+            <div v-else-if="mintState === 'showing-link'" class="share-sheet__mint-result">
+              <p class="share-sheet__mint-result-title">Link for "{{ mintLabel }}"</p>
+              <div class="share-sheet__qr" v-html="mintQrSvg"/>
+              <button type="button"
+                      class="share-sheet__button"
+                      @click="copyMintedLink">
+                {{ copiedMinted ? 'Copied!' : 'Copy link' }}
+              </button>
+              <button type="button"
+                      class="share-sheet__button share-sheet__button--primary"
+                      @click="doneMinting">
+                Done
+              </button>
+            </div>
+          </div>
+
+          <!-- Delete list -->
+          <div class="share-sheet__section share-sheet__section--danger">
+            <button type="button"
+                    class="share-sheet__button share-sheet__button--destructive"
+                    @click="confirmDelete">
+              Delete shared list…
+            </button>
+          </div>
+        </div>
+      </template>
     </div>
   </dialog>
+
+  <confirm-modal v-model:open="confirmOpen"
+                 :title="confirmTitle"
+                 :message="confirmMessage"
+                 variant="destructive"
+                 :confirm-label="confirmLabel"
+                 @confirm="onConfirmed"/>
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import type List from '@/classes/List'
 import { useLiveRegion } from '@/composables/useLiveRegion'
+import ConfirmModal from '@/components/ConfirmModal.vue'
 import * as sync from '@/sync'
+import type { EditorToken } from '@/sync/types'
 
 const props = defineProps<{ open: boolean; list: List }>()
 const emit = defineEmits<{
   (e: 'update:open', value: boolean): void
   (e: 'provisioned', listId: string): void
+  (e: 'deleted'): void
 }>()
 
 const dialog = ref<HTMLDialogElement | null>(null)
 const state = ref<'loading' | 'ready' | 'error'>('loading')
+const activeTab = ref<'share' | 'manage'>('share')
 const qrSvg = ref('')
 const joinUrl = ref('')
 const copied = ref(false)
+const copiedOriginal = ref(false)
 const canWebShare = ref(typeof navigator !== 'undefined' && typeof navigator.share === 'function')
 const { announce } = useLiveRegion()
 
+// Manage tab state
+const editorTokens = computed<EditorToken[]>(() =>
+  sync.getMeta(props.list.id)?.editorTokens ?? []
+)
+const isOwner = computed(() => sync.getMeta(props.list.id)?.role === 'owner')
+const revoking = ref<string | null>(null)
+
+// Mint flow
+const mintState = ref<'idle' | 'entering-label' | 'generating' | 'showing-link'>('idle')
+const mintLabel = ref('')
+const mintQrSvg = ref('')
+const mintedJoinUrl = ref('')
+const copiedMinted = ref(false)
+
+// Confirm modal
+const confirmOpen = ref(false)
+const confirmTitle = ref('')
+const confirmMessage = ref('')
+const confirmLabel = ref('Confirm')
+let pendingConfirmAction: (() => Promise<void>) | null = null
+
 let copyTimer: ReturnType<typeof setTimeout> | null = null
+let copyOriginalTimer: ReturnType<typeof setTimeout> | null = null
+let copyMintedTimer: ReturnType<typeof setTimeout> | null = null
 let provisionedListId: string | null = null
 
 async function build () {
@@ -106,6 +266,10 @@ function onClose () {
     provisionedListId = null
   }
   emit('update:open', false)
+  mintState.value = 'idle'
+  mintLabel.value = ''
+  mintQrSvg.value = ''
+  mintedJoinUrl.value = ''
 }
 
 function onBackdropClick (event: MouseEvent) {
@@ -138,6 +302,112 @@ async function onCopy () {
   }
 }
 
+async function copyOriginalLink () {
+  if (!joinUrl.value) return
+  try {
+    await navigator.clipboard.writeText(joinUrl.value)
+    copiedOriginal.value = true
+    announce('Original link copied to clipboard')
+    if (copyOriginalTimer) clearTimeout(copyOriginalTimer)
+    copyOriginalTimer = setTimeout(() => { copiedOriginal.value = false }, 2000)
+  } catch {
+    announce('Could not copy link')
+  }
+}
+
+async function copyEditorLink (et: EditorToken) {
+  const url = `${window.location.origin}/#join=${props.list.id}.${et.token}`
+  try {
+    await navigator.clipboard.writeText(url)
+    announce(`Link for ${et.label} copied`)
+  } catch {
+    announce('Could not copy link')
+  }
+}
+
+async function generateEditorLink () {
+  if (!mintLabel.value.trim()) return
+  mintState.value = 'generating'
+
+  const result = await sync.mintEditorToken(props.list.id, mintLabel.value.trim())
+  if (!result) {
+    mintState.value = 'idle'
+    announce('Could not generate editor link')
+    return
+  }
+
+  mintedJoinUrl.value = result.joinUrl
+  const qrcodeMod = await import('qrcode')
+  const QRCode = qrcodeMod.default ?? qrcodeMod
+  mintQrSvg.value = await QRCode.toString(result.joinUrl, {
+    type: 'svg',
+    margin: 1,
+    color: { dark: '#111827', light: '#ffffff' }
+  })
+  mintState.value = 'showing-link'
+}
+
+async function copyMintedLink () {
+  if (!mintedJoinUrl.value) return
+  try {
+    await navigator.clipboard.writeText(mintedJoinUrl.value)
+    copiedMinted.value = true
+    announce('Editor link copied to clipboard')
+    if (copyMintedTimer) clearTimeout(copyMintedTimer)
+    copyMintedTimer = setTimeout(() => { copiedMinted.value = false }, 2000)
+  } catch {
+    announce('Could not copy link')
+  }
+}
+
+function doneMinting () {
+  mintState.value = 'idle'
+  mintLabel.value = ''
+  mintQrSvg.value = ''
+  mintedJoinUrl.value = ''
+  copiedMinted.value = false
+}
+
+function confirmRevoke (et: EditorToken) {
+  confirmTitle.value = 'Revoke editor link'
+  confirmMessage.value = `Revoke access for "${et.label}"? Their link will stop working immediately.`
+  confirmLabel.value = 'Revoke'
+  pendingConfirmAction = async () => {
+    revoking.value = et.hash
+    const ok = await sync.revokeEditorToken(props.list.id, et.hash)
+    revoking.value = null
+    if (ok) {
+      announce(`Access for ${et.label} revoked`)
+    } else {
+      announce('Could not revoke — check your connection')
+    }
+  }
+  confirmOpen.value = true
+}
+
+function confirmDelete () {
+  confirmTitle.value = 'Delete shared list'
+  confirmMessage.value = `Delete "${props.list.n}"? All devices will lose access and the list will be removed everywhere.`
+  confirmLabel.value = 'Delete'
+  pendingConfirmAction = async () => {
+    const ok = await sync.deleteList(props.list.id)
+    if (ok) {
+      close()
+      emit('deleted')
+    } else {
+      announce('Could not delete — check your connection')
+    }
+  }
+  confirmOpen.value = true
+}
+
+async function onConfirmed () {
+  if (pendingConfirmAction) {
+    await pendingConfirmAction()
+    pendingConfirmAction = null
+  }
+}
+
 onMounted(async () => {
   if (props.open) {
     dialog.value?.showModal()
@@ -148,6 +418,7 @@ onMounted(async () => {
 watch(() => props.open, async (isOpen) => {
   if (isOpen) {
     if (!dialog.value?.open) dialog.value?.showModal()
+    activeTab.value = 'share'
     await build()
   } else if (dialog.value?.open) {
     dialog.value.close()
@@ -156,6 +427,8 @@ watch(() => props.open, async (isOpen) => {
 
 onUnmounted(() => {
   if (copyTimer) clearTimeout(copyTimer)
+  if (copyOriginalTimer) clearTimeout(copyOriginalTimer)
+  if (copyMintedTimer) clearTimeout(copyMintedTimer)
 })
 </script>
 
@@ -187,6 +460,23 @@ onUnmounted(() => {
 
     &:hover, &:focus {
       @apply text-red-700 outline-none;
+    }
+  }
+
+  &__tabs {
+    @apply flex border-b border-gl-gray mb-4;
+    @apply dark:border-gl-deep-blue;
+  }
+
+  &__tab {
+    @apply px-4 py-2 text-sm font-medium border-b-2 border-transparent -mb-px transition-colors duration-150;
+
+    &:hover {
+      @apply text-gl-blueberry;
+    }
+
+    &--active {
+      @apply border-gl-blueberry text-gl-blueberry;
     }
   }
 
@@ -234,6 +524,110 @@ onUnmounted(() => {
         @apply dark:bg-green-800 dark:ring-gl-green/30 dark:border-gl-lightgreen;
       }
     }
+
+    &--destructive {
+      @apply bg-red-600 border-red-700 text-white;
+      @apply dark:bg-red-700 dark:border-red-800;
+
+      &:hover, &:focus {
+        @apply bg-red-700 ring-4 ring-red-400/50 border-red-700;
+        @apply dark:bg-red-800 dark:ring-red-500/30 dark:border-red-800;
+      }
+    }
+  }
+
+  &__manage {
+    @apply flex flex-col gap-4;
+  }
+
+  &__section {
+    @apply flex flex-col gap-2;
+
+    &--danger {
+      @apply pt-2 border-t border-gl-gray;
+      @apply dark:border-gl-deep-blue;
+    }
+  }
+
+  &__section-title {
+    @apply text-sm font-semibold;
+  }
+
+  &__section-desc {
+    @apply text-xs text-gray-500 dark:text-gray-400;
+  }
+
+  &__count {
+    @apply font-normal text-gray-500 dark:text-gray-400;
+  }
+
+  &__empty {
+    @apply text-xs text-gray-400 italic;
+  }
+
+  &__token-list {
+    @apply flex flex-col gap-1 list-none p-0 m-0;
+  }
+
+  &__token-item {
+    @apply flex items-center gap-2 py-1;
+  }
+
+  &__token-label {
+    @apply text-sm flex-1 truncate;
+  }
+
+  &__token-action {
+    @apply text-base p-1 rounded transition-colors duration-150 min-w-[32px] min-h-[32px] flex items-center justify-center;
+
+    &:hover, &:focus {
+      @apply bg-blue-50 outline-none;
+      @apply dark:bg-gl-deep-blue;
+    }
+
+    &:disabled {
+      @apply opacity-50 cursor-not-allowed;
+    }
+
+    &--revoke {
+      &:hover, &:focus {
+        @apply bg-red-50 text-red-600;
+        @apply dark:bg-red-900/30;
+      }
+    }
+  }
+
+  &__mint-trigger {
+    @apply mt-1;
+  }
+
+  &__mint-form {
+    @apply flex flex-col gap-2 mt-1;
+  }
+
+  &__mint-label-text {
+    @apply text-xs font-medium;
+  }
+
+  &__mint-input {
+    @apply px-3 py-2 rounded border border-gl-gray text-sm outline-none transition duration-200;
+    @apply dark:border-gl-deep-blue dark:bg-gl-deep-blue/50 dark:text-gray-200;
+
+    &:focus {
+      @apply ring-2 ring-blue-300/50 border-blue-300;
+    }
+  }
+
+  &__mint-actions {
+    @apply grid grid-cols-2 gap-2;
+  }
+
+  &__mint-result {
+    @apply flex flex-col gap-2 mt-1;
+  }
+
+  &__mint-result-title {
+    @apply text-xs font-medium text-center;
   }
 }
 </style>

--- a/src/components/ToastContainer.vue
+++ b/src/components/ToastContainer.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="toast-container" aria-live="assertive" aria-atomic="false">
+    <div v-for="toast in toastStore.toasts"
+         :key="toast.id"
+         class="toast"
+         :class="toast.type === 'error' ? 'toast--error' : 'toast--info'">
+      <span class="toast__message">{{ toast.message }}</span>
+      <button type="button"
+              class="toast__close"
+              :aria-label="`Dismiss: ${toast.message}`"
+              @click="toastStore.dismiss(toast.id)">
+        <font-awesome-icon icon="times-circle"/>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useToastStore } from '@/stores/toast'
+
+const toastStore = useToastStore()
+</script>
+
+<style lang="scss">
+@reference "../assets/main.css";
+
+.toast-container {
+  @apply fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex flex-col gap-2 items-center pointer-events-none w-full max-w-sm px-4;
+}
+
+.toast {
+  @apply flex items-center justify-between gap-3 w-full rounded-lg px-4 py-3 shadow-lg pointer-events-auto;
+
+  &--error {
+    @apply bg-red-600 text-white;
+  }
+
+  &--info {
+    @apply bg-gl-darkblue text-white;
+    @apply dark:bg-white dark:text-gl-darkblue;
+  }
+
+  &__message {
+    @apply text-sm font-medium;
+  }
+
+  &__close {
+    @apply text-lg shrink-0 opacity-80 hover:opacity-100 focus:opacity-100 focus:outline-none;
+  }
+}
+</style>

--- a/src/stores/toast.ts
+++ b/src/stores/toast.ts
@@ -1,0 +1,26 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+
+interface Toast {
+  id: number
+  message: string
+  type: 'info' | 'error'
+}
+
+export const useToastStore = defineStore('toast', () => {
+  const toasts = ref<Toast[]>([])
+  let nextId = 0
+
+  function add (message: string, type: Toast['type'] = 'info'): void {
+    const id = nextId++
+    toasts.value.push({ id, message, type })
+    setTimeout(() => dismiss(id), 5000)
+  }
+
+  function dismiss (id: number): void {
+    const idx = toasts.value.findIndex(t => t.id === id)
+    if (idx !== -1) toasts.value.splice(idx, 1)
+  }
+
+  return { toasts, add, dismiss }
+})

--- a/src/sync/cleanup.ts
+++ b/src/sync/cleanup.ts
@@ -1,0 +1,10 @@
+import { getMeta, removeMeta } from './storage'
+import { useListsStore } from '@/stores/lists'
+
+// Removes syncMeta and deletes the list from the local store.
+// Does NOT stop the poller or touch pendingOps — callers handle those.
+export function cleanupListLocally (listId: string): void {
+  if (!getMeta(listId)) return
+  removeMeta(listId)
+  useListsStore().deleteList(listId)
+}

--- a/src/sync/crypto.ts
+++ b/src/sync/crypto.ts
@@ -1,0 +1,8 @@
+export async function hashToken (token: string): Promise<string> {
+  const data = new TextEncoder().encode(token)
+  const hash = await crypto.subtle.digest('SHA-256', data)
+  let bin = ''
+  const bytes = new Uint8Array(hash)
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+}

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -1,10 +1,12 @@
 import type List from '@/classes/List'
 import { useListsStore } from '@/stores/lists'
-import { provisionList, joinList } from './transport'
+import { provisionList, joinList, mintToken, revokeToken, deleteListRequest } from './transport'
 import { applyJoinPayload } from './reconcile'
-import { getMeta, setMeta, getSyncMetaMap } from './storage'
-import { startPoller } from './poll'
+import { getMeta, setMeta, getSyncMetaMap, saveSyncMetaMap } from './storage'
+import { startPoller, stopPoller } from './poll'
 import { startDrainer } from './queue'
+import { cleanupListLocally } from './cleanup'
+import { hashToken } from './crypto'
 
 export { getMeta, getSyncMetaMap, saveSyncMetaMap } from './storage'
 export { enqueue } from './queue'
@@ -51,4 +53,60 @@ export function startPolling (): void {
     startPoller(listId)
   }
   startDrainer()
+}
+
+export async function mintEditorToken (
+  listId: string,
+  label: string
+): Promise<{ token: string; hash: string; joinUrl: string } | null> {
+  const meta = getMeta(listId)
+  if (!meta || meta.role !== 'owner') return null
+
+  const result = await mintToken(listId, meta.authToken)
+  if (!result.ok) return null
+
+  const { token } = result.data
+  const hash = await hashToken(token)
+  const joinUrl = `${window.location.origin}/#join=${listId}.${token}`
+
+  const map = getSyncMetaMap()
+  const entry = map[listId]
+  if (entry) {
+    entry.editorTokens = [...(entry.editorTokens ?? []), { token, hash, label }]
+    saveSyncMetaMap(map)
+  }
+
+  return { token, hash, joinUrl }
+}
+
+export async function revokeEditorToken (
+  listId: string,
+  tokenHash: string
+): Promise<boolean> {
+  const meta = getMeta(listId)
+  if (!meta || meta.role !== 'owner') return false
+
+  const result = await revokeToken(listId, meta.authToken, tokenHash)
+  if (!result.ok) return false
+
+  const map = getSyncMetaMap()
+  const entry = map[listId]
+  if (entry?.editorTokens) {
+    entry.editorTokens = entry.editorTokens.filter(t => t.hash !== tokenHash)
+    saveSyncMetaMap(map)
+  }
+
+  return true
+}
+
+export async function deleteList (listId: string): Promise<boolean> {
+  const meta = getMeta(listId)
+  if (!meta || meta.role !== 'owner') return false
+
+  const result = await deleteListRequest(listId, meta.authToken)
+  if (!result.ok) return false
+
+  stopPoller(listId)
+  cleanupListLocally(listId)
+  return true
 }

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -6,7 +6,6 @@ import { getMeta, setMeta, getSyncMetaMap, saveSyncMetaMap } from './storage'
 import { startPoller, stopPoller } from './poll'
 import { startDrainer } from './queue'
 import { cleanupListLocally } from './cleanup'
-import { hashToken } from './crypto'
 
 export { getMeta, getSyncMetaMap, saveSyncMetaMap } from './storage'
 export { enqueue } from './queue'
@@ -55,44 +54,39 @@ export function startPolling (): void {
   startDrainer()
 }
 
-export async function mintEditorToken (
-  listId: string,
-  label: string
-): Promise<{ token: string; hash: string; joinUrl: string } | null> {
+export async function enableSharing (listId: string): Promise<string | null> {
   const meta = getMeta(listId)
   if (!meta || meta.role !== 'owner') return null
+
+  if (meta.shareToken) {
+    return `${window.location.origin}/#join=${listId}.${meta.shareToken}`
+  }
 
   const result = await mintToken(listId, meta.authToken)
   if (!result.ok) return null
 
   const { token } = result.data
-  const hash = await hashToken(token)
-  const joinUrl = `${window.location.origin}/#join=${listId}.${token}`
-
   const map = getSyncMetaMap()
   const entry = map[listId]
   if (entry) {
-    entry.editorTokens = [...(entry.editorTokens ?? []), { token, hash, label }]
+    entry.shareToken = token
     saveSyncMetaMap(map)
   }
 
-  return { token, hash, joinUrl }
+  return `${window.location.origin}/#join=${listId}.${token}`
 }
 
-export async function revokeEditorToken (
-  listId: string,
-  tokenHash: string
-): Promise<boolean> {
+export async function disableSharing (listId: string): Promise<boolean> {
   const meta = getMeta(listId)
   if (!meta || meta.role !== 'owner') return false
 
-  const result = await revokeToken(listId, meta.authToken, tokenHash)
+  const result = await revokeToken(listId, meta.authToken)
   if (!result.ok) return false
 
   const map = getSyncMetaMap()
   const entry = map[listId]
-  if (entry?.editorTokens) {
-    entry.editorTokens = entry.editorTokens.filter(t => t.hash !== tokenHash)
+  if (entry) {
+    delete entry.shareToken
     saveSyncMetaMap(map)
   }
 

--- a/src/sync/poll.ts
+++ b/src/sync/poll.ts
@@ -1,6 +1,9 @@
 import { pollList } from './transport'
 import { applyPollPayload } from './reconcile'
 import { getMeta, getSyncMetaMap, saveSyncMetaMap } from './storage'
+import { cleanupListLocally } from './cleanup'
+import { useListsStore } from '@/stores/lists'
+import { useToastStore } from '@/stores/toast'
 
 const POLL_INTERVAL_MS = 5_000
 const MAX_BACKOFF_MS = 60_000
@@ -65,7 +68,15 @@ async function runPoller (listId: string, state: PollState): Promise<void> {
       }
       await sleep(POLL_INTERVAL_MS)
     } else if (result.error.kind === 'unauthorized' || result.error.kind === 'not-found') {
+      const listName = useListsStore().getListFromId(listId)?.n ?? 'a shared list'
+      useToastStore().add(
+        result.error.kind === 'unauthorized'
+          ? `Access to "${listName}" was revoked.`
+          : `"${listName}" was deleted.`,
+        'error'
+      )
       stopPoller(listId)
+      cleanupListLocally(listId)
       break
     } else {
       await sleep(state.backoff)

--- a/src/sync/queue.ts
+++ b/src/sync/queue.ts
@@ -1,8 +1,9 @@
 import { useListsStore } from '@/stores/lists'
-import { getMeta, removeMeta } from './storage'
+import { useToastStore } from '@/stores/toast'
+import { getMeta } from './storage'
 import { upsertItem, patchList } from './transport'
 import { reconcileServerItem } from './reconcile'
-import { stopPoller } from './poll'
+import { cleanupListLocally } from './cleanup'
 import type { Op, UpsertItemResponse, PatchListResponse } from './types'
 
 const QUEUE_KEY = 'pendingOps'
@@ -45,12 +46,6 @@ function sleep (ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-function teardownList (listId: string): void {
-  saveQueue(loadQueue().filter(o => o.listId !== listId))
-  removeMeta(listId)
-  stopPoller(listId)
-  useListsStore().deleteList(listId)
-}
 
 async function flush (): Promise<void> {
   while (true) {
@@ -88,7 +83,15 @@ async function flush (): Promise<void> {
       result.error.kind === 'unauthorized' ||
       result.error.kind === 'not-found'
     ) {
-      teardownList(op.listId)
+      const listName = useListsStore().getListFromId(op.listId)?.n ?? 'a shared list'
+      useToastStore().add(
+        result.error.kind === 'unauthorized'
+          ? `Access to "${listName}" was revoked.`
+          : `"${listName}" was deleted.`,
+        'error'
+      )
+      saveQueue(loadQueue().filter(o => o.listId !== op.listId))
+      cleanupListLocally(op.listId)
     } else {
       await sleep(backoffMs)
       backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS)

--- a/src/sync/queue.ts
+++ b/src/sync/queue.ts
@@ -46,7 +46,6 @@ function sleep (ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-
 async function flush (): Promise<void> {
   while (true) {
     const q = loadQueue()

--- a/src/sync/transport.ts
+++ b/src/sync/transport.ts
@@ -118,17 +118,12 @@ export async function mintToken (
 
 export async function revokeToken (
   listId: string,
-  authToken: string,
-  tokenHash: string
+  authToken: string
 ): Promise<TransportResult<Record<string, never>>> {
   try {
     const res = await fetch(`/api/lists/${listId}/tokens/revoke`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${authToken}`
-      },
-      body: JSON.stringify({ tokenHash })
+      headers: { Authorization: `Bearer ${authToken}` }
     })
     if (!res.ok) return { ok: false, error: normError(res.status) }
     return { ok: true, data: {} as Record<string, never> }

--- a/src/sync/transport.ts
+++ b/src/sync/transport.ts
@@ -1,4 +1,4 @@
-import type { TransportResult, ProvisionResponse, JoinResponse, PollPayload, ItemPayload, UpsertItemResponse, PatchListResponse } from './types'
+import type { TransportResult, ProvisionResponse, JoinResponse, PollPayload, ItemPayload, UpsertItemResponse, PatchListResponse, MintTokenResponse } from './types'
 
 function normError (status: number) {
   if (status === 401) return { kind: 'unauthorized' as const }
@@ -95,6 +95,59 @@ export async function patchList (
     })
     if (!res.ok) return { ok: false, error: normError(res.status) }
     return { ok: true, data: await res.json() as PatchListResponse }
+  } catch {
+    return { ok: false, error: { kind: 'network' } }
+  }
+}
+
+export async function mintToken (
+  listId: string,
+  authToken: string
+): Promise<TransportResult<MintTokenResponse>> {
+  try {
+    const res = await fetch(`/api/lists/${listId}/tokens`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${authToken}` }
+    })
+    if (!res.ok) return { ok: false, error: normError(res.status) }
+    return { ok: true, data: await res.json() as MintTokenResponse }
+  } catch {
+    return { ok: false, error: { kind: 'network' } }
+  }
+}
+
+export async function revokeToken (
+  listId: string,
+  authToken: string,
+  tokenHash: string
+): Promise<TransportResult<Record<string, never>>> {
+  try {
+    const res = await fetch(`/api/lists/${listId}/tokens/revoke`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authToken}`
+      },
+      body: JSON.stringify({ tokenHash })
+    })
+    if (!res.ok) return { ok: false, error: normError(res.status) }
+    return { ok: true, data: {} as Record<string, never> }
+  } catch {
+    return { ok: false, error: { kind: 'network' } }
+  }
+}
+
+export async function deleteListRequest (
+  listId: string,
+  authToken: string
+): Promise<TransportResult<Record<string, never>>> {
+  try {
+    const res = await fetch(`/api/lists/${listId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${authToken}` }
+    })
+    if (!res.ok) return { ok: false, error: normError(res.status) }
+    return { ok: true, data: {} as Record<string, never> }
   } catch {
     return { ok: false, error: { kind: 'network' } }
   }

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -1,15 +1,8 @@
-export interface EditorToken {
-  token: string
-  hash: string
-  label: string
-}
-
 export interface SyncMeta {
   authToken: string
   role: 'owner' | 'editor'
   lastVersion: number
-  label?: string
-  editorTokens?: EditorToken[]
+  shareToken?: string
 }
 
 export type SyncMetaMap = Record<string, SyncMeta>

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -1,8 +1,15 @@
+export interface EditorToken {
+  token: string
+  hash: string
+  label: string
+}
+
 export interface SyncMeta {
   authToken: string
   role: 'owner' | 'editor'
   lastVersion: number
   label?: string
+  editorTokens?: EditorToken[]
 }
 
 export type SyncMetaMap = Record<string, SyncMeta>
@@ -43,6 +50,10 @@ export interface UpsertItemResponse {
 export interface PatchListResponse {
   name: string
   u: number
+}
+
+export interface MintTokenResponse {
+  token: string
 }
 
 export interface UpsertItemOp {

--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -137,7 +137,7 @@ const shareOpen = ref(false)
 const shareList = shallowRef<List | null>(null)
 
 watch(list, (current) => {
-  if (!current) router.replace({ name: 'Lists' })
+  if (!current && !shareOpen.value) router.replace({ name: 'Lists' })
 })
 
 function openShare () {

--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -135,9 +135,10 @@ const quantity = ref<number>(1)
 const itemName = ref<HTMLInputElement | null>(null)
 const shareOpen = ref(false)
 const shareList = shallowRef<List | null>(null)
+const provisioning = ref(false)
 
-watch([list, shareOpen], ([currentList, isOpen]) => {
-  if (!currentList && !isOpen) router.replace({ name: 'Lists' })
+watch([list, shareOpen, provisioning], ([currentList, isOpen, isProvisioning]) => {
+  if (!currentList && !isOpen && !isProvisioning) router.replace({ name: 'Lists' })
 })
 
 function openShare () {
@@ -148,7 +149,10 @@ function openShare () {
 }
 
 function onProvisioned (newListId: string) {
-  router.replace({ name: 'List', params: { id: newListId } })
+  provisioning.value = true
+  router.replace({ name: 'List', params: { id: newListId } }).finally(() => {
+    provisioning.value = false
+  })
 }
 
 function onListDeleted () {

--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -109,7 +109,8 @@
   <share-sheet v-if="shareList"
                v-model:open="shareOpen"
                :list="shareList"
-               @provisioned="onProvisioned"/>
+               @provisioned="onProvisioned"
+               @deleted="onListDeleted"/>
   </div>
 </template>
 
@@ -144,6 +145,10 @@ function openShare () {
 
 function onProvisioned (newListId: string) {
   router.replace({ name: 'List', params: { id: newListId } })
+}
+
+function onListDeleted () {
+  router.replace({ name: 'Lists' })
 }
 
 function addItemToList (): void {

--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -115,7 +115,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, shallowRef, onMounted, nextTick } from 'vue'
+import { computed, ref, shallowRef, watch, onMounted, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import Item from '@/classes/Item'
 import { useListsStore } from '@/stores/lists'
@@ -135,6 +135,10 @@ const quantity = ref<number>(1)
 const itemName = ref<HTMLInputElement | null>(null)
 const shareOpen = ref(false)
 const shareList = shallowRef<List | null>(null)
+
+watch(list, (current) => {
+  if (!current) router.replace({ name: 'Lists' })
+})
 
 function openShare () {
   if (list.value) {

--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -128,8 +128,8 @@ const router = useRouter()
 const listsStore = useListsStore()
 const { announce } = useLiveRegion()
 
-const listId = route.params.id as string
-const list = computed(() => listsStore.getListFromId(listId))
+const listId = computed(() => route.params.id as string)
+const list = computed(() => listsStore.getListFromId(listId.value))
 const name = ref<string | null>(null)
 const quantity = ref<number>(1)
 const itemName = ref<HTMLInputElement | null>(null)
@@ -157,7 +157,7 @@ function onListDeleted () {
 
 function addItemToList (): void {
   const addedName = name.value!
-  listsStore.addItem(listId, new Item(addedName, String(quantity.value)))
+  listsStore.addItem(listId.value, new Item(addedName, String(quantity.value)))
   name.value = null
   quantity.value = 1
   announce(`${addedName} added`)
@@ -168,7 +168,7 @@ function modifyItemQuantity (event: Event, id: string): void {
   const input = event.target as HTMLInputElement
   const item = list.value!.i.find(i => i.id === id)!
   if (input.value && !isNaN(Number(input.value))) {
-    listsStore.updateItem(listId, id, { q: input.value })
+    listsStore.updateItem(listId.value, id, { q: input.value })
   } else {
     input.value = item.q
   }
@@ -177,7 +177,7 @@ function modifyItemQuantity (event: Event, id: string): void {
 function modifyItemName (event: Event, id: string): void {
   const input = event.target as HTMLInputElement
   if (input.value) {
-    listsStore.updateItem(listId, id, { n: input.value })
+    listsStore.updateItem(listId.value, id, { n: input.value })
   }
 }
 
@@ -185,7 +185,7 @@ async function deleteItem (id: string): Promise<void> {
   const item = list.value!.i.find(i => i.id === id)
   if (!item) return
   const deletedName = item.n
-  listsStore.softDeleteItem(listId, id)
+  listsStore.softDeleteItem(listId.value, id)
   announce(`${deletedName} removed`)
   await nextTick()
   const nextInput = document.querySelector<HTMLInputElement>('.item__name')
@@ -200,7 +200,7 @@ function toggleItemCheckedStatus (id: string): void {
   const item = list.value!.i.find(i => i.id === id)
   if (!item) return
   const next = item.c === 0 ? 1 : 0
-  listsStore.updateItem(listId, id, { c: next })
+  listsStore.updateItem(listId.value, id, { c: next })
   announce(`${item.n} ${next === 1 ? 'checked' : 'unchecked'}`)
 }
 

--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -136,8 +136,8 @@ const itemName = ref<HTMLInputElement | null>(null)
 const shareOpen = ref(false)
 const shareList = shallowRef<List | null>(null)
 
-watch(list, (current) => {
-  if (!current && !shareOpen.value) router.replace({ name: 'Lists' })
+watch([list, shareOpen], ([currentList, isOpen]) => {
+  if (!currentList && !isOpen) router.replace({ name: 'Lists' })
 })
 
 function openShare () {

--- a/tests/integration/api/lists.spec.ts
+++ b/tests/integration/api/lists.spec.ts
@@ -470,56 +470,48 @@ describe('POST /api/lists/:id/tokens/revoke', () => {
     return handleProvision(db, req).then(r => r.json() as Promise<{ id: string; authToken: string }>)
   }
 
-  async function hashToken (token: string): Promise<string> {
-    const data = new TextEncoder().encode(token)
-    const hash = await crypto.subtle.digest('SHA-256', data)
-    let bin = ''
-    const bytes = new Uint8Array(hash)
-    for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
-    return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+  function revokeReq (listId: string, token: string) {
+    return new Request(`http://localhost/api/lists/${listId}/tokens/revoke`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` }
+    })
   }
 
-  it('revokes a minted editor token', async () => {
+  it('revokes all editor tokens for the list', async () => {
     const { id, authToken } = await setup()
     const { token: editorToken } = await handleMintToken(db, new Request(`http://localhost/api/lists/${id}/tokens`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${authToken}` }
     }), id).then(r => r.json() as Promise<{ token: string }>)
 
-    const editorHash = await hashToken(editorToken)
-    const revokeReq = new Request(`http://localhost/api/lists/${id}/tokens/revoke`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` },
-      body: JSON.stringify({ tokenHash: editorHash })
-    })
-    const res = await handleRevokeToken(db, revokeReq, id)
+    const res = await handleRevokeToken(db, revokeReq(id, authToken), id)
     expect(res.status).toBe(200)
 
-    const pollReq = new Request(`http://localhost/api/lists/${id}?since=0`, {
+    const pollRes = await handlePoll(db, new Request(`http://localhost/api/lists/${id}?since=0`, {
       headers: { Authorization: `Bearer ${editorToken}` }
-    })
-    const pollRes = await handlePoll(db, pollReq, id)
+    }), id)
     expect(pollRes.status).toBe(401)
   })
 
-  it('returns 400 when trying to revoke own token', async () => {
+  it('owner token remains valid after revoking editors', async () => {
     const { id, authToken } = await setup()
-    const ownerHash = await hashToken(authToken)
-    const revokeReq = new Request(`http://localhost/api/lists/${id}/tokens/revoke`, {
+    await handleMintToken(db, new Request(`http://localhost/api/lists/${id}/tokens`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` },
-      body: JSON.stringify({ tokenHash: ownerHash })
-    })
-    const res = await handleRevokeToken(db, revokeReq, id)
-    expect(res.status).toBe(400)
+      headers: { Authorization: `Bearer ${authToken}` }
+    }), id)
+
+    await handleRevokeToken(db, revokeReq(id, authToken), id)
+
+    const pollRes = await handlePoll(db, new Request(`http://localhost/api/lists/${id}?since=0`, {
+      headers: { Authorization: `Bearer ${authToken}` }
+    }), id)
+    expect(pollRes.status).toBe(200)
   })
 
   it('returns 401 without auth', async () => {
     const { id } = await setup()
     const res = await handleRevokeToken(db, new Request(`http://localhost/api/lists/${id}/tokens/revoke`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tokenHash: 'abc' })
+      method: 'POST'
     }), id)
     expect(res.status).toBe(401)
   })

--- a/tests/integration/api/lists.spec.ts
+++ b/tests/integration/api/lists.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import { Miniflare } from 'miniflare'
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
-import { handleProvision, handleJoin, handlePoll, handleUpsertItem, handlePatchList } from '../../../functions/api/_shared/handlers'
+import { handleProvision, handleJoin, handlePoll, handleUpsertItem, handlePatchList, handleMintToken, handleRevokeToken, handleDeleteList } from '../../../functions/api/_shared/handlers'
 
 const schema = readFileSync(resolve(__dirname, '../../../schema.sql'), 'utf-8')
 
@@ -404,5 +404,191 @@ describe('PATCH /api/lists/:id', () => {
       body: JSON.stringify({ name: 'Hacked', u: 9999 })
     }), id)
     expect(res.status).toBe(401)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/lists/:id/tokens (mint editor token)
+// ---------------------------------------------------------------------------
+
+describe('POST /api/lists/:id/tokens', () => {
+  async function setup () {
+    const req = new Request('http://localhost/api/lists', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Token Test', items: [] })
+    })
+    return handleProvision(db, req).then(r => r.json() as Promise<{ id: string; authToken: string }>)
+  }
+
+  function mintReq (listId: string, token: string) {
+    return new Request(`http://localhost/api/lists/${listId}/tokens`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` }
+    })
+  }
+
+  it('mints a new editor token for the owner', async () => {
+    const { id, authToken } = await setup()
+    const res = await handleMintToken(db, mintReq(id, authToken), id)
+    expect(res.status).toBe(200)
+    const body = await res.json() as { token: string }
+    expect(typeof body.token).toBe('string')
+    expect(body.token.length).toBeGreaterThan(30)
+  })
+
+  it('minted token is valid for polling', async () => {
+    const { id, authToken } = await setup()
+    const { token: editorToken } = await handleMintToken(db, mintReq(id, authToken), id)
+      .then(r => r.json() as Promise<{ token: string }>)
+
+    const pollReq = new Request(`http://localhost/api/lists/${id}?since=0`, {
+      headers: { Authorization: `Bearer ${editorToken}` }
+    })
+    const res = await handlePoll(db, pollReq, id)
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 401 without auth', async () => {
+    const { id } = await setup()
+    const res = await handleMintToken(db, new Request(`http://localhost/api/lists/${id}/tokens`, { method: 'POST' }), id)
+    expect(res.status).toBe(401)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/lists/:id/tokens/revoke
+// ---------------------------------------------------------------------------
+
+describe('POST /api/lists/:id/tokens/revoke', () => {
+  async function setup () {
+    const req = new Request('http://localhost/api/lists', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Revoke Test', items: [] })
+    })
+    return handleProvision(db, req).then(r => r.json() as Promise<{ id: string; authToken: string }>)
+  }
+
+  async function hashToken (token: string): Promise<string> {
+    const data = new TextEncoder().encode(token)
+    const hash = await crypto.subtle.digest('SHA-256', data)
+    let bin = ''
+    const bytes = new Uint8Array(hash)
+    for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+    return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+  }
+
+  it('revokes a minted editor token', async () => {
+    const { id, authToken } = await setup()
+    const { token: editorToken } = await handleMintToken(db, new Request(`http://localhost/api/lists/${id}/tokens`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${authToken}` }
+    }), id).then(r => r.json() as Promise<{ token: string }>)
+
+    const editorHash = await hashToken(editorToken)
+    const revokeReq = new Request(`http://localhost/api/lists/${id}/tokens/revoke`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` },
+      body: JSON.stringify({ tokenHash: editorHash })
+    })
+    const res = await handleRevokeToken(db, revokeReq, id)
+    expect(res.status).toBe(200)
+
+    const pollReq = new Request(`http://localhost/api/lists/${id}?since=0`, {
+      headers: { Authorization: `Bearer ${editorToken}` }
+    })
+    const pollRes = await handlePoll(db, pollReq, id)
+    expect(pollRes.status).toBe(401)
+  })
+
+  it('returns 400 when trying to revoke own token', async () => {
+    const { id, authToken } = await setup()
+    const ownerHash = await hashToken(authToken)
+    const revokeReq = new Request(`http://localhost/api/lists/${id}/tokens/revoke`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` },
+      body: JSON.stringify({ tokenHash: ownerHash })
+    })
+    const res = await handleRevokeToken(db, revokeReq, id)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 401 without auth', async () => {
+    const { id } = await setup()
+    const res = await handleRevokeToken(db, new Request(`http://localhost/api/lists/${id}/tokens/revoke`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tokenHash: 'abc' })
+    }), id)
+    expect(res.status).toBe(401)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DELETE /api/lists/:id
+// ---------------------------------------------------------------------------
+
+describe('DELETE /api/lists/:id', () => {
+  async function setup () {
+    const req = new Request('http://localhost/api/lists', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Delete Test',
+        items: [{ id: 'item0001', n: 'Milk', q: '1', c: 0, u: 1000, d: 0 }]
+      })
+    })
+    return handleProvision(db, req).then(r => r.json() as Promise<{ id: string; authToken: string }>)
+  }
+
+  function deleteReq (listId: string, token: string) {
+    return new Request(`http://localhost/api/lists/${listId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` }
+    })
+  }
+
+  it('deletes list and cascades to items and tokens', async () => {
+    const { id, authToken } = await setup()
+    const res = await handleDeleteList(db, deleteReq(id, authToken), id)
+    expect(res.status).toBe(200)
+
+    const pollReq = new Request(`http://localhost/api/lists/${id}?since=0`, {
+      headers: { Authorization: `Bearer ${authToken}` }
+    })
+    const pollRes = await handlePoll(db, pollReq, id)
+    expect(pollRes.status).toBe(401) // token gone, can't auth
+  })
+
+  it('returns 401 without auth', async () => {
+    const { id } = await setup()
+    const res = await handleDeleteList(db, new Request(`http://localhost/api/lists/${id}`, { method: 'DELETE' }), id)
+    expect(res.status).toBe(401)
+  })
+
+  it('tombstone GC — removes d=1 items older than 30 days on write', async () => {
+    const { id, authToken } = await setup()
+    const thirtyOneDaysAgo = Date.now() - 31 * 24 * 60 * 60 * 1000
+
+    const upsertReq = (itemId: string, item: object) => new Request(`http://localhost/api/lists/${id}/items/${itemId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` },
+      body: JSON.stringify(item)
+    })
+
+    // Insert old tombstone
+    await handleUpsertItem(db, upsertReq('tombstone1', { n: 'Old Item', q: '1', c: 0, u: thirtyOneDaysAgo, d: 1 }), id, 'tombstone1')
+    // Write a new item to trigger GC
+    await handleUpsertItem(db, upsertReq('item0002', { n: 'New Item', q: '2', c: 0, u: Date.now(), d: 0 }), id, 'item0002')
+
+    // Poll — old tombstone should be gone
+    const pollReq = new Request(`http://localhost/api/lists/${id}?since=0`, {
+      headers: { Authorization: `Bearer ${authToken}` }
+    })
+    const body = await handlePoll(db, pollReq, id).then(r => r.json() as Promise<{ items: Array<{ id: string }> }>)
+    const ids = body.items.map(i => i.id)
+    expect(ids).not.toContain('tombstone1')
+    expect(ids).toContain('item0002')
   })
 })

--- a/tests/integration/api/lists.spec.ts
+++ b/tests/integration/api/lists.spec.ts
@@ -569,7 +569,7 @@ describe('DELETE /api/lists/:id', () => {
 
   it('tombstone GC — removes d=1 items older than 30 days on write', async () => {
     const { id, authToken } = await setup()
-    const thirtyOneDaysAgo = Date.now() - 31 * 24 * 60 * 60 * 1000
+    const ninetyOneDaysAgo = Date.now() - 91 * 24 * 60 * 60 * 1000
 
     const upsertReq = (itemId: string, item: object) => new Request(`http://localhost/api/lists/${id}/items/${itemId}`, {
       method: 'POST',
@@ -578,7 +578,7 @@ describe('DELETE /api/lists/:id', () => {
     })
 
     // Insert old tombstone
-    await handleUpsertItem(db, upsertReq('tombstone1', { n: 'Old Item', q: '1', c: 0, u: thirtyOneDaysAgo, d: 1 }), id, 'tombstone1')
+    await handleUpsertItem(db, upsertReq('tombstone1', { n: 'Old Item', q: '1', c: 0, u: ninetyOneDaysAgo, d: 1 }), id, 'tombstone1')
     // Write a new item to trigger GC
     await handleUpsertItem(db, upsertReq('item0002', { n: 'New Item', q: '2', c: 0, u: Date.now(), d: 0 }), id, 'item0002')
 

--- a/tests/unit/components/ShareSheet.spec.js
+++ b/tests/unit/components/ShareSheet.spec.js
@@ -2,10 +2,13 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import ShareSheet from '@/components/ShareSheet.vue'
 
-const { provisionMock, isSyncedMock, getMetaMock } = vi.hoisted(() => ({
+const { provisionMock, isSyncedMock, getMetaMock, enableSharingMock, disableSharingMock, deleteListMock } = vi.hoisted(() => ({
   provisionMock: vi.fn(),
   isSyncedMock: vi.fn(),
-  getMetaMock: vi.fn()
+  getMetaMock: vi.fn(),
+  enableSharingMock: vi.fn(),
+  disableSharingMock: vi.fn(),
+  deleteListMock: vi.fn()
 }))
 
 vi.mock('qrcode', () => ({
@@ -15,14 +18,20 @@ vi.mock('qrcode', () => ({
 vi.mock('@/sync', () => ({
   provision: (...args) => provisionMock(...args),
   isSynced: (...args) => isSyncedMock(...args),
-  getMeta: (...args) => getMetaMock(...args)
+  getMeta: (...args) => getMetaMock(...args),
+  enableSharing: (...args) => enableSharingMock(...args),
+  disableSharing: (...args) => disableSharingMock(...args),
+  deleteList: (...args) => deleteListMock(...args)
 }))
 
 const list = { id: 'l1', n: 'Costco', i: [{ id: 'i1', n: 'Eggs', q: '1', c: 0, u: 1, d: 0 }] }
 
+const OWNER_META = { authToken: 'owner-tok', role: 'owner', lastVersion: 1, shareToken: 'share-tok' }
+const SHARE_URL = 'https://example.com/#join=l1.share-tok'
+
 const mountSheet = (props = {}) => mount(ShareSheet, {
   props: { open: false, list, ...props },
-  global: { stubs: { FontAwesomeIcon: { template: '<span/>' } } },
+  global: { stubs: { FontAwesomeIcon: { template: '<span/>' }, ConfirmModal: { template: '<div/>', props: ['open', 'title', 'message', 'variant', 'confirmLabel'] } } },
   attachTo: document.body
 })
 
@@ -31,6 +40,10 @@ describe('ShareSheet', () => {
     vi.clearAllMocks()
     isSyncedMock.mockReturnValue(false)
     provisionMock.mockResolvedValue({ joinUrl: 'https://example.com/#join=ID.TOKEN', listId: 'ID' })
+    enableSharingMock.mockResolvedValue(SHARE_URL)
+    disableSharingMock.mockResolvedValue(true)
+    deleteListMock.mockResolvedValue(true)
+    getMetaMock.mockReturnValue(null)
     HTMLDialogElement.prototype.showModal = vi.fn(function () { this.open = true })
     HTMLDialogElement.prototype.close = vi.fn(function () {
       this.open = false
@@ -52,22 +65,34 @@ describe('ShareSheet', () => {
     wrapper.unmount()
   })
 
-  it('calls provision and renders QR when opened for an unsynced list', async () => {
+  it('calls provision and enableSharing then renders QR for an unsynced list', async () => {
     const wrapper = mountSheet({ open: true })
     await flushPromises()
     expect(provisionMock).toHaveBeenCalledWith(list)
+    expect(enableSharingMock).toHaveBeenCalled()
     expect(wrapper.html()).toContain('mock-qr')
     expect(wrapper.text()).not.toContain('Setting up')
     wrapper.unmount()
   })
 
-  it('uses existing authToken instead of provisioning for a synced list', async () => {
+  it('skips provision and shows QR for a synced owner with shareToken', async () => {
     isSyncedMock.mockReturnValue(true)
-    getMetaMock.mockReturnValue({ authToken: 'EXISTINGTOKEN', role: 'owner', lastVersion: 1 })
+    getMetaMock.mockReturnValue(OWNER_META)
     const wrapper = mountSheet({ open: true })
     await flushPromises()
     expect(provisionMock).not.toHaveBeenCalled()
     expect(wrapper.html()).toContain('mock-qr')
+    wrapper.unmount()
+  })
+
+  it('shows not-sharing state for a synced owner without shareToken', async () => {
+    isSyncedMock.mockReturnValue(true)
+    getMetaMock.mockReturnValue({ authToken: 'owner-tok', role: 'owner', lastVersion: 1 })
+    const wrapper = mountSheet({ open: true })
+    await flushPromises()
+    expect(provisionMock).not.toHaveBeenCalled()
+    expect(wrapper.html()).not.toContain('mock-qr')
+    expect(wrapper.text()).toContain('Enable sharing')
     wrapper.unmount()
   })
 
@@ -84,14 +109,43 @@ describe('ShareSheet', () => {
     const wrapper = mountSheet({ open: true })
     await flushPromises()
     await wrapper.findAll('button').find(b => b.text().includes('Copy link')).trigger('click')
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('https://example.com/#join=ID.TOKEN')
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(SHARE_URL)
   })
 
   it('invokes navigator.share when Share link is clicked', async () => {
     const wrapper = mountSheet({ open: true })
     await flushPromises()
     await wrapper.findAll('button').find(b => b.text().includes('Share link')).trigger('click')
-    expect(navigator.share).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://example.com/#join=ID.TOKEN' }))
+    expect(navigator.share).toHaveBeenCalledWith(expect.objectContaining({ url: SHARE_URL }))
+  })
+
+  it('clicking Enable sharing calls enableSharing and shows QR', async () => {
+    isSyncedMock.mockReturnValue(true)
+    getMetaMock.mockReturnValue({ authToken: 'owner-tok', role: 'owner', lastVersion: 1 })
+    const wrapper = mountSheet({ open: true })
+    await flushPromises()
+
+    await wrapper.findAll('button').find(b => b.text().includes('Enable sharing')).trigger('click')
+    await flushPromises()
+
+    expect(enableSharingMock).toHaveBeenCalledWith('l1')
+    expect(wrapper.html()).toContain('mock-qr')
+    wrapper.unmount()
+  })
+
+  it('clicking Stop sharing calls disableSharing and shows Enable button', async () => {
+    isSyncedMock.mockReturnValue(true)
+    getMetaMock.mockReturnValue(OWNER_META)
+    const wrapper = mountSheet({ open: true })
+    await flushPromises()
+
+    await wrapper.findAll('button').find(b => b.text().includes('Stop sharing')).trigger('click')
+    await flushPromises()
+
+    expect(disableSharingMock).toHaveBeenCalledWith('l1')
+    expect(wrapper.html()).not.toContain('mock-qr')
+    expect(wrapper.text()).toContain('Enable sharing')
+    wrapper.unmount()
   })
 
   it('emits provisioned + update:open=false when closed after provision', async () => {
@@ -105,7 +159,7 @@ describe('ShareSheet', () => {
 
   it('does not emit provisioned when closing without provision', async () => {
     isSyncedMock.mockReturnValue(true)
-    getMetaMock.mockReturnValue({ authToken: 'T', role: 'owner', lastVersion: 1 })
+    getMetaMock.mockReturnValue(OWNER_META)
     const wrapper = mountSheet({ open: true })
     await flushPromises()
     await wrapper.find('.share-sheet__close').trigger('click')

--- a/tests/unit/stores/toast.spec.ts
+++ b/tests/unit/stores/toast.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useToastStore } from '@/stores/toast'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  setActivePinia(createPinia())
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useToastStore', () => {
+  it('add appends a toast with the given message and type', () => {
+    const store = useToastStore()
+    store.add('Hello', 'error')
+    expect(store.toasts).toHaveLength(1)
+    expect(store.toasts[0]).toMatchObject({ message: 'Hello', type: 'error' })
+  })
+
+  it('add defaults type to info', () => {
+    const store = useToastStore()
+    store.add('Info message')
+    expect(store.toasts[0].type).toBe('info')
+  })
+
+  it('dismiss removes the toast by id', () => {
+    const store = useToastStore()
+    store.add('One')
+    store.add('Two')
+    const id = store.toasts[0].id
+    store.dismiss(id)
+    expect(store.toasts).toHaveLength(1)
+    expect(store.toasts[0].message).toBe('Two')
+  })
+
+  it('dismiss is a no-op for an unknown id', () => {
+    const store = useToastStore()
+    store.add('One')
+    store.dismiss(9999)
+    expect(store.toasts).toHaveLength(1)
+  })
+
+  it('auto-dismisses after 5 seconds', () => {
+    const store = useToastStore()
+    store.add('Timed')
+    expect(store.toasts).toHaveLength(1)
+    vi.advanceTimersByTime(5000)
+    expect(store.toasts).toHaveLength(0)
+  })
+
+  it('multiple toasts each auto-dismiss independently', () => {
+    const store = useToastStore()
+    store.add('First')
+    vi.advanceTimersByTime(2000)
+    store.add('Second')
+    vi.advanceTimersByTime(3000)
+    expect(store.toasts).toHaveLength(1)
+    expect(store.toasts[0].message).toBe('Second')
+    vi.advanceTimersByTime(2000)
+    expect(store.toasts).toHaveLength(0)
+  })
+})

--- a/tests/unit/sync/cleanup.spec.ts
+++ b/tests/unit/sync/cleanup.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { cleanupListLocally } from '@/sync/cleanup'
+import { getMeta, setMeta } from '@/sync/storage'
+import { useListsStore } from '@/stores/lists'
+
+vi.mock('@/sync/poll', () => ({ stopPoller: vi.fn() }))
+
+beforeEach(() => {
+  localStorage.clear()
+  setActivePinia(createPinia())
+  vi.resetAllMocks()
+})
+
+describe('cleanupListLocally', () => {
+  it('does nothing when meta is absent', () => {
+    const store = useListsStore()
+    store.$patch({ lists: [{ id: 'list1', n: 'Test', i: [] }] })
+    cleanupListLocally('list1')
+    expect(store.lists).toHaveLength(1)
+  })
+
+  it('removes meta and deletes list from store when meta exists', () => {
+    const store = useListsStore()
+    store.$patch({ lists: [{ id: 'list1', n: 'Test', i: [] }] })
+    setMeta('list1', { authToken: 'tok', role: 'owner', lastVersion: 1 })
+
+    cleanupListLocally('list1')
+
+    expect(getMeta('list1')).toBeNull()
+    expect(store.lists).toHaveLength(0)
+  })
+
+  it('is idempotent — second call is a no-op', () => {
+    const store = useListsStore()
+    store.$patch({ lists: [{ id: 'list1', n: 'Test', i: [] }] })
+    setMeta('list1', { authToken: 'tok', role: 'owner', lastVersion: 1 })
+
+    cleanupListLocally('list1')
+    cleanupListLocally('list1')
+
+    expect(getMeta('list1')).toBeNull()
+    expect(store.lists).toHaveLength(0)
+  })
+})

--- a/tests/unit/sync/crypto.spec.ts
+++ b/tests/unit/sync/crypto.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { hashToken } from '@/sync/crypto'
+
+describe('hashToken', () => {
+  it('returns a non-empty base64url string', async () => {
+    const hash = await hashToken('some-token')
+    expect(typeof hash).toBe('string')
+    expect(hash.length).toBeGreaterThan(10)
+    expect(hash).not.toMatch(/[+/=]/)
+  })
+
+  it('is deterministic — same input yields same hash', async () => {
+    expect(await hashToken('abc')).toBe(await hashToken('abc'))
+  })
+
+  it('produces distinct hashes for distinct inputs', async () => {
+    expect(await hashToken('token-a')).not.toBe(await hashToken('token-b'))
+  })
+})

--- a/tests/unit/sync/owner-actions.spec.ts
+++ b/tests/unit/sync/owner-actions.spec.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mintEditorToken, revokeEditorToken, deleteList } from '@/sync'
+import { mintToken, revokeToken, deleteListRequest } from '@/sync/transport'
+import { stopPoller } from '@/sync/poll'
+import { cleanupListLocally } from '@/sync/cleanup'
+import { getMeta, setMeta } from '@/sync/storage'
+
+vi.mock('@/sync/transport', () => ({
+  provisionList: vi.fn(),
+  joinList: vi.fn(),
+  mintToken: vi.fn(),
+  revokeToken: vi.fn(),
+  deleteListRequest: vi.fn()
+}))
+vi.mock('@/sync/poll', () => ({ startPoller: vi.fn(), stopPoller: vi.fn() }))
+vi.mock('@/sync/cleanup', () => ({ cleanupListLocally: vi.fn() }))
+vi.mock('@/sync/queue', () => ({ startDrainer: vi.fn(), enqueue: vi.fn() }))
+vi.mock('@/sync/reconcile', () => ({ applyJoinPayload: vi.fn() }))
+vi.mock('@/stores/lists', () => ({ useListsStore: vi.fn() }))
+
+const mMintToken = vi.mocked(mintToken)
+const mRevokeToken = vi.mocked(revokeToken)
+const mDeleteListRequest = vi.mocked(deleteListRequest)
+const mStopPoller = vi.mocked(stopPoller)
+const mCleanupListLocally = vi.mocked(cleanupListLocally)
+
+const OWNER_META = { authToken: 'owner-tok', role: 'owner' as const, lastVersion: 1 }
+const EDITOR_META = { authToken: 'editor-tok', role: 'editor' as const, lastVersion: 1 }
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.resetAllMocks()
+})
+
+describe('mintEditorToken', () => {
+  it('returns null when list is not synced', async () => {
+    expect(await mintEditorToken('list1', 'label')).toBeNull()
+    expect(mMintToken).not.toHaveBeenCalled()
+  })
+
+  it('returns null when role is editor', async () => {
+    setMeta('list1', EDITOR_META)
+    expect(await mintEditorToken('list1', 'label')).toBeNull()
+  })
+
+  it('returns null when mintToken fails', async () => {
+    setMeta('list1', OWNER_META)
+    mMintToken.mockResolvedValue({ ok: false, error: { kind: 'network' } })
+    expect(await mintEditorToken('list1', 'Sarah')).toBeNull()
+  })
+
+  it('returns token, hash, joinUrl and persists to editorTokens', async () => {
+    setMeta('list1', OWNER_META)
+    mMintToken.mockResolvedValue({ ok: true, data: { token: 'new-tok' } })
+
+    const result = await mintEditorToken('list1', 'Sarah')
+
+    expect(result).not.toBeNull()
+    expect(result!.token).toBe('new-tok')
+    expect(typeof result!.hash).toBe('string')
+    expect(result!.hash.length).toBeGreaterThan(10)
+    expect(result!.joinUrl).toContain('#join=list1.new-tok')
+
+    const meta = getMeta('list1')!
+    expect(meta.editorTokens).toHaveLength(1)
+    expect(meta.editorTokens![0]).toMatchObject({ token: 'new-tok', label: 'Sarah' })
+  })
+
+  it('appends to existing editorTokens', async () => {
+    setMeta('list1', {
+      ...OWNER_META,
+      editorTokens: [{ token: 'old-tok', hash: 'old-hash', label: 'Old' }]
+    })
+    mMintToken.mockResolvedValue({ ok: true, data: { token: 'new-tok' } })
+
+    await mintEditorToken('list1', 'New')
+
+    expect(getMeta('list1')!.editorTokens).toHaveLength(2)
+  })
+})
+
+describe('revokeEditorToken', () => {
+  it('returns false when list is not synced', async () => {
+    expect(await revokeEditorToken('list1', 'hash1')).toBe(false)
+  })
+
+  it('returns false when role is editor', async () => {
+    setMeta('list1', EDITOR_META)
+    expect(await revokeEditorToken('list1', 'hash1')).toBe(false)
+  })
+
+  it('returns false when revokeToken fails', async () => {
+    setMeta('list1', OWNER_META)
+    mRevokeToken.mockResolvedValue({ ok: false, error: { kind: 'network' } })
+    expect(await revokeEditorToken('list1', 'hash1')).toBe(false)
+  })
+
+  it('returns true and removes the token from editorTokens', async () => {
+    setMeta('list1', {
+      ...OWNER_META,
+      editorTokens: [
+        { token: 'tok-a', hash: 'hash-a', label: 'A' },
+        { token: 'tok-b', hash: 'hash-b', label: 'B' }
+      ]
+    })
+    mRevokeToken.mockResolvedValue({ ok: true, data: {} as Record<string, never> })
+
+    expect(await revokeEditorToken('list1', 'hash-a')).toBe(true)
+
+    const tokens = getMeta('list1')!.editorTokens!
+    expect(tokens).toHaveLength(1)
+    expect(tokens[0].hash).toBe('hash-b')
+  })
+})
+
+describe('deleteList', () => {
+  it('returns false when list is not synced', async () => {
+    expect(await deleteList('list1')).toBe(false)
+    expect(mDeleteListRequest).not.toHaveBeenCalled()
+  })
+
+  it('returns false when role is editor', async () => {
+    setMeta('list1', EDITOR_META)
+    expect(await deleteList('list1')).toBe(false)
+  })
+
+  it('returns false when server returns error', async () => {
+    setMeta('list1', OWNER_META)
+    mDeleteListRequest.mockResolvedValue({ ok: false, error: { kind: 'network' } })
+    expect(await deleteList('list1')).toBe(false)
+    expect(mStopPoller).not.toHaveBeenCalled()
+  })
+
+  it('returns true and calls stopPoller + cleanupListLocally on success', async () => {
+    setMeta('list1', OWNER_META)
+    mDeleteListRequest.mockResolvedValue({ ok: true, data: {} as Record<string, never> })
+
+    expect(await deleteList('list1')).toBe(true)
+    expect(mDeleteListRequest).toHaveBeenCalledWith('list1', 'owner-tok')
+    expect(mStopPoller).toHaveBeenCalledWith('list1')
+    expect(mCleanupListLocally).toHaveBeenCalledWith('list1')
+  })
+})

--- a/tests/unit/sync/owner-actions.spec.ts
+++ b/tests/unit/sync/owner-actions.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mintEditorToken, revokeEditorToken, deleteList } from '@/sync'
+import { enableSharing, disableSharing, deleteList } from '@/sync'
 import { mintToken, revokeToken, deleteListRequest } from '@/sync/transport'
 import { stopPoller } from '@/sync/poll'
 import { cleanupListLocally } from '@/sync/cleanup'
@@ -32,84 +32,65 @@ beforeEach(() => {
   vi.resetAllMocks()
 })
 
-describe('mintEditorToken', () => {
+describe('enableSharing', () => {
   it('returns null when list is not synced', async () => {
-    expect(await mintEditorToken('list1', 'label')).toBeNull()
+    expect(await enableSharing('list1')).toBeNull()
     expect(mMintToken).not.toHaveBeenCalled()
   })
 
   it('returns null when role is editor', async () => {
     setMeta('list1', EDITOR_META)
-    expect(await mintEditorToken('list1', 'label')).toBeNull()
+    expect(await enableSharing('list1')).toBeNull()
+  })
+
+  it('returns existing share URL without minting when shareToken already exists', async () => {
+    setMeta('list1', { ...OWNER_META, shareToken: 'existing-tok' })
+    const url = await enableSharing('list1')
+    expect(url).toContain('#join=list1.existing-tok')
+    expect(mMintToken).not.toHaveBeenCalled()
   })
 
   it('returns null when mintToken fails', async () => {
     setMeta('list1', OWNER_META)
     mMintToken.mockResolvedValue({ ok: false, error: { kind: 'network' } })
-    expect(await mintEditorToken('list1', 'Sarah')).toBeNull()
+    expect(await enableSharing('list1')).toBeNull()
   })
 
-  it('returns token, hash, joinUrl and persists to editorTokens', async () => {
+  it('returns join URL and persists shareToken to meta', async () => {
     setMeta('list1', OWNER_META)
     mMintToken.mockResolvedValue({ ok: true, data: { token: 'new-tok' } })
 
-    const result = await mintEditorToken('list1', 'Sarah')
+    const url = await enableSharing('list1')
 
-    expect(result).not.toBeNull()
-    expect(result!.token).toBe('new-tok')
-    expect(typeof result!.hash).toBe('string')
-    expect(result!.hash.length).toBeGreaterThan(10)
-    expect(result!.joinUrl).toContain('#join=list1.new-tok')
-
-    const meta = getMeta('list1')!
-    expect(meta.editorTokens).toHaveLength(1)
-    expect(meta.editorTokens![0]).toMatchObject({ token: 'new-tok', label: 'Sarah' })
-  })
-
-  it('appends to existing editorTokens', async () => {
-    setMeta('list1', {
-      ...OWNER_META,
-      editorTokens: [{ token: 'old-tok', hash: 'old-hash', label: 'Old' }]
-    })
-    mMintToken.mockResolvedValue({ ok: true, data: { token: 'new-tok' } })
-
-    await mintEditorToken('list1', 'New')
-
-    expect(getMeta('list1')!.editorTokens).toHaveLength(2)
+    expect(url).toContain('#join=list1.new-tok')
+    expect(getMeta('list1')!.shareToken).toBe('new-tok')
   })
 })
 
-describe('revokeEditorToken', () => {
+describe('disableSharing', () => {
   it('returns false when list is not synced', async () => {
-    expect(await revokeEditorToken('list1', 'hash1')).toBe(false)
+    expect(await disableSharing('list1')).toBe(false)
   })
 
   it('returns false when role is editor', async () => {
     setMeta('list1', EDITOR_META)
-    expect(await revokeEditorToken('list1', 'hash1')).toBe(false)
+    expect(await disableSharing('list1')).toBe(false)
   })
 
   it('returns false when revokeToken fails', async () => {
-    setMeta('list1', OWNER_META)
+    setMeta('list1', { ...OWNER_META, shareToken: 'tok' })
     mRevokeToken.mockResolvedValue({ ok: false, error: { kind: 'network' } })
-    expect(await revokeEditorToken('list1', 'hash1')).toBe(false)
+    expect(await disableSharing('list1')).toBe(false)
+    expect(getMeta('list1')!.shareToken).toBe('tok')
   })
 
-  it('returns true and removes the token from editorTokens', async () => {
-    setMeta('list1', {
-      ...OWNER_META,
-      editorTokens: [
-        { token: 'tok-a', hash: 'hash-a', label: 'A' },
-        { token: 'tok-b', hash: 'hash-b', label: 'B' }
-      ]
-    })
+  it('returns true and removes shareToken from meta', async () => {
+    setMeta('list1', { ...OWNER_META, shareToken: 'tok' })
     mRevokeToken.mockResolvedValue({ ok: true, data: {} as Record<string, never> })
 
-    expect(await revokeEditorToken('list1', 'hash-a')).toBe(true)
-
-    const tokens = getMeta('list1')!.editorTokens!
-    expect(tokens).toHaveLength(1)
-    expect(tokens[0].hash).toBe('hash-b')
+    expect(await disableSharing('list1')).toBe(true)
+    expect(getMeta('list1')!.shareToken).toBeUndefined()
+    expect(mRevokeToken).toHaveBeenCalledWith('list1', 'owner-tok')
   })
 })
 

--- a/tests/unit/sync/poll.spec.ts
+++ b/tests/unit/sync/poll.spec.ts
@@ -11,6 +11,9 @@ vi.mock('@/sync/storage', () => ({
   getSyncMetaMap: vi.fn(() => ({})),
   saveSyncMetaMap: vi.fn()
 }))
+vi.mock('@/sync/cleanup', () => ({ cleanupListLocally: vi.fn() }))
+vi.mock('@/stores/lists', () => ({ useListsStore: vi.fn(() => ({ getListFromId: vi.fn(() => ({ n: 'Test List' })) })) }))
+vi.mock('@/stores/toast', () => ({ useToastStore: vi.fn(() => ({ add: vi.fn() })) }))
 
 const mGetMeta = vi.mocked(getMeta)
 const mPollList = vi.mocked(pollList)

--- a/tests/unit/sync/queue.spec.ts
+++ b/tests/unit/sync/queue.spec.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
-import { getMeta, removeMeta } from '@/sync/storage'
+import { getMeta } from '@/sync/storage'
 import { upsertItem } from '@/sync/transport'
 import { reconcileServerItem } from '@/sync/reconcile'
-import { stopPoller } from '@/sync/poll'
+import { cleanupListLocally } from '@/sync/cleanup'
 import { useListsStore } from '@/stores/lists'
+import { useToastStore } from '@/stores/toast'
 import { enqueue, startDrainer, _resetForTest } from '@/sync/queue'
 
 vi.mock('@/sync/storage', () => ({
@@ -25,8 +26,16 @@ vi.mock('@/sync/poll', () => ({
   stopPoller: vi.fn()
 }))
 
+vi.mock('@/sync/cleanup', () => ({
+  cleanupListLocally: vi.fn()
+}))
+
 vi.mock('@/stores/lists', () => ({
   useListsStore: vi.fn()
+}))
+
+vi.mock('@/stores/toast', () => ({
+  useToastStore: vi.fn(() => ({ add: vi.fn() }))
 }))
 
 const ITEM = { id: 'item0001', n: 'Milk', q: '1', c: 0, u: 1000, d: 0 }
@@ -44,6 +53,8 @@ beforeEach(() => {
   localStorage.clear()
   setActivePinia(createPinia())
   vi.resetAllMocks()
+  vi.mocked(useToastStore).mockReturnValue({ add: vi.fn() } as unknown as ReturnType<typeof useToastStore>)
+  vi.mocked(useListsStore).mockReturnValue({ getListFromId: vi.fn(), deleteList: vi.fn(), mergeList: vi.fn() } as unknown as ReturnType<typeof useListsStore>)
 })
 
 afterEach(() => {
@@ -121,30 +132,34 @@ describe('flush — missing meta', () => {
 })
 
 describe('flush — 401/404 teardown', () => {
-  it('tears down on 401: removes meta, stops poller, deletes list', async () => {
+  it('tears down on 401: calls cleanupListLocally and shows revoke toast', async () => {
     vi.mocked(getMeta).mockReturnValue(META)
     vi.mocked(upsertItem).mockResolvedValue({ ok: false, error: { kind: 'unauthorized' } })
-    const store = mockStore()
+    mockStore()
+    const toastAdd = vi.fn()
+    vi.mocked(useToastStore).mockReturnValue({ add: toastAdd } as unknown as ReturnType<typeof useToastStore>)
 
     enqueue({ kind: 'upsertItem', listId: 'list1', item: ITEM })
     await vi.runAllTimersAsync()
 
-    expect(vi.mocked(removeMeta)).toHaveBeenCalledWith('list1')
-    expect(vi.mocked(stopPoller)).toHaveBeenCalledWith('list1')
-    expect(store.deleteList).toHaveBeenCalledWith('list1')
+    expect(vi.mocked(cleanupListLocally)).toHaveBeenCalledWith('list1')
+    expect(toastAdd).toHaveBeenCalledWith(expect.stringContaining('revoked'), 'error')
     const q = JSON.parse(localStorage.getItem('pendingOps') ?? '[]') as unknown[]
     expect(q).toHaveLength(0)
   })
 
-  it('tears down on 404', async () => {
+  it('tears down on 404: calls cleanupListLocally and shows deleted toast', async () => {
     vi.mocked(getMeta).mockReturnValue(META)
     vi.mocked(upsertItem).mockResolvedValue({ ok: false, error: { kind: 'not-found' } })
-    const store = mockStore()
+    mockStore()
+    const toastAdd = vi.fn()
+    vi.mocked(useToastStore).mockReturnValue({ add: toastAdd } as unknown as ReturnType<typeof useToastStore>)
 
     enqueue({ kind: 'upsertItem', listId: 'list1', item: ITEM })
     await vi.runAllTimersAsync()
 
-    expect(store.deleteList).toHaveBeenCalledWith('list1')
+    expect(vi.mocked(cleanupListLocally)).toHaveBeenCalledWith('list1')
+    expect(toastAdd).toHaveBeenCalledWith(expect.stringContaining('deleted'), 'error')
   })
 
   it('drops only the affected list ops, leaves other lists intact', async () => {

--- a/tests/unit/sync/transport.spec.ts
+++ b/tests/unit/sync/transport.spec.ts
@@ -104,18 +104,18 @@ describe('sync/transport', () => {
   describe('revokeToken', () => {
     it('returns ok on 200', async () => {
       vi.stubGlobal('fetch', mockFetch(true, 200, {}))
-      const result = await revokeToken('list1', 'owner-tok', 'hash1')
+      const result = await revokeToken('list1', 'owner-tok')
       expect(result.ok).toBe(true)
     })
 
     it('returns unauthorized on 401', async () => {
       vi.stubGlobal('fetch', mockFetch(false, 401, {}))
-      expect(await revokeToken('list1', 'bad', 'hash1')).toEqual({ ok: false, error: { kind: 'unauthorized' } })
+      expect(await revokeToken('list1', 'bad')).toEqual({ ok: false, error: { kind: 'unauthorized' } })
     })
 
     it('returns network error when fetch throws', async () => {
       vi.stubGlobal('fetch', mockNetworkError())
-      expect(await revokeToken('list1', 'tok', 'hash1')).toEqual({ ok: false, error: { kind: 'network' } })
+      expect(await revokeToken('list1', 'tok')).toEqual({ ok: false, error: { kind: 'network' } })
     })
   })
 

--- a/tests/unit/sync/transport.spec.ts
+++ b/tests/unit/sync/transport.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { provisionList, joinList, pollList } from '@/sync/transport'
+import { provisionList, joinList, pollList, mintToken, revokeToken, deleteListRequest } from '@/sync/transport'
 
 const mockFetch = (ok: boolean, status: number, data: unknown) =>
   vi.fn().mockResolvedValue({ ok, status, json: () => Promise.resolve(data) })
@@ -81,6 +81,58 @@ describe('sync/transport', () => {
     it('returns network error when fetch throws', async () => {
       vi.stubGlobal('fetch', mockNetworkError())
       expect(await pollList('abc', 'tok', 0)).toEqual({ ok: false, error: { kind: 'network' } })
+    })
+  })
+
+  describe('mintToken', () => {
+    it('returns token on 200', async () => {
+      vi.stubGlobal('fetch', mockFetch(true, 200, { token: 'new-tok' }))
+      expect(await mintToken('list1', 'owner-tok')).toEqual({ ok: true, data: { token: 'new-tok' } })
+    })
+
+    it('returns unauthorized on 403', async () => {
+      vi.stubGlobal('fetch', mockFetch(false, 403, {}))
+      expect(await mintToken('list1', 'editor-tok')).toEqual({ ok: false, error: { kind: 'server', status: 403 } })
+    })
+
+    it('returns network error when fetch throws', async () => {
+      vi.stubGlobal('fetch', mockNetworkError())
+      expect(await mintToken('list1', 'tok')).toEqual({ ok: false, error: { kind: 'network' } })
+    })
+  })
+
+  describe('revokeToken', () => {
+    it('returns ok on 200', async () => {
+      vi.stubGlobal('fetch', mockFetch(true, 200, {}))
+      const result = await revokeToken('list1', 'owner-tok', 'hash1')
+      expect(result.ok).toBe(true)
+    })
+
+    it('returns unauthorized on 401', async () => {
+      vi.stubGlobal('fetch', mockFetch(false, 401, {}))
+      expect(await revokeToken('list1', 'bad', 'hash1')).toEqual({ ok: false, error: { kind: 'unauthorized' } })
+    })
+
+    it('returns network error when fetch throws', async () => {
+      vi.stubGlobal('fetch', mockNetworkError())
+      expect(await revokeToken('list1', 'tok', 'hash1')).toEqual({ ok: false, error: { kind: 'network' } })
+    })
+  })
+
+  describe('deleteListRequest', () => {
+    it('returns ok on 200', async () => {
+      vi.stubGlobal('fetch', mockFetch(true, 200, {}))
+      expect((await deleteListRequest('list1', 'tok')).ok).toBe(true)
+    })
+
+    it('returns unauthorized on 401', async () => {
+      vi.stubGlobal('fetch', mockFetch(false, 401, {}))
+      expect(await deleteListRequest('list1', 'bad')).toEqual({ ok: false, error: { kind: 'unauthorized' } })
+    })
+
+    it('returns network error when fetch throws', async () => {
+      vi.stubGlobal('fetch', mockNetworkError())
+      expect(await deleteListRequest('list1', 'tok')).toEqual({ ok: false, error: { kind: 'network' } })
     })
   })
 })

--- a/tests/unit/views/List.spec.js
+++ b/tests/unit/views/List.spec.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import { nextTick } from 'vue'
 import { createRouter, createMemoryHistory } from 'vue-router'
@@ -11,6 +11,11 @@ const makeItem = (overrides = {}) => ({
   id: 'item1', n: 'Apples', q: 2, c: 0, d: 0, u: 0, ...overrides
 })
 
+const routes = [
+  { path: '/list/:id', name: 'List', component: { template: '<div/>' } },
+  { path: '/lists', name: 'Lists', component: { template: '<div/>' } }
+]
+
 const mountList = async (items = [makeItem()]) => {
   const pinia = createPinia()
 
@@ -21,10 +26,7 @@ const mountList = async (items = [makeItem()]) => {
     }
   }
 
-  const router = createRouter({
-    history: createMemoryHistory(),
-    routes: [{ path: '/list/:id', name: 'List', component: { template: '<div/>' } }]
-  })
+  const router = createRouter({ history: createMemoryHistory(), routes })
   await router.push({ name: 'List', params: { id: listId } })
 
   const wrapper = mount(ListV, {
@@ -36,7 +38,36 @@ const mountList = async (items = [makeItem()]) => {
 
   await nextTick()
   const store = useListsStore(pinia)
-  return { wrapper, store }
+  return { wrapper, store, router }
+}
+
+// Mounts with a controllable ShareSheet stub so we can drive its events.
+const mountListWithSheet = async () => {
+  const pinia = createPinia()
+  const seeder = {
+    install () {
+      useListsStore(pinia).$patch({ lists: [{ id: 'local01', n: 'Groceries', i: [] }] })
+    }
+  }
+  const router = createRouter({ history: createMemoryHistory(), routes })
+  await router.push({ name: 'List', params: { id: 'local01' } })
+
+  let sheetEmit = null
+  const ShareSheetStub = {
+    props: ['open', 'list'],
+    emits: ['update:open', 'provisioned', 'deleted'],
+    setup (_, { emit }) { sheetEmit = emit; return () => null }
+  }
+
+  const wrapper = mount(ListV, {
+    global: {
+      plugins: [pinia, seeder, router],
+      stubs: { FontAwesomeIcon: { template: '<span/>' }, ShareSheet: ShareSheetStub }
+    }
+  })
+  await nextTick()
+  const store = useListsStore(pinia)
+  return { wrapper, store, router, sheetEmit: () => sheetEmit }
 }
 
 describe('List.vue', () => {
@@ -101,5 +132,41 @@ describe('List.vue', () => {
   it('shows the all-checked banner when every active item is checked', async () => {
     const { wrapper } = await mountList([makeItem({ c: 1 })])
     expect(wrapper.text()).toContain('checked off all your items')
+  })
+
+  describe('navigation guard', () => {
+    it('does NOT navigate to Lists when the share button is clicked', async () => {
+      const { wrapper, router } = await mountListWithSheet()
+      await wrapper.find('.list-header__share').trigger('click')
+      await nextTick()
+      expect(router.currentRoute.value.name).toBe('List')
+    })
+
+    it('does NOT navigate to Lists when the share sheet closes after provision', async () => {
+      const { wrapper, store, router, sheetEmit } = await mountListWithSheet()
+
+      // Open share sheet
+      await wrapper.find('.list-header__share').trigger('click')
+      await nextTick()
+
+      // Simulate provision: list ID renamed in store (as sync.provision does)
+      store.updateListId('local01', 'SERVER01')
+      await nextTick()
+
+      // Simulate ShareSheet emitting provisioned then closing (as onClose does)
+      sheetEmit()('provisioned', 'SERVER01')
+      sheetEmit()('update:open', false)
+      await flushPromises()
+
+      expect(router.currentRoute.value.name).toBe('List')
+      expect(router.currentRoute.value.params.id).toBe('SERVER01')
+    })
+
+    it('navigates to Lists when the list disappears without a provision (access revoked)', async () => {
+      const { store, router } = await mountList([])
+      store.$patch({ lists: [] })
+      await flushPromises()
+      expect(router.currentRoute.value.name).toBe('Lists')
+    })
   })
 })


### PR DESCRIPTION
## Summary

- **3 server endpoints:** \`POST /api/lists/:id/tokens\` (mint editor share token), \`POST /api/lists/:id/tokens/revoke\` (revokes **all** editor tokens for the list — no hash needed), \`DELETE /api/lists/:id\` (owner hard-delete, explicit cascade)
- **Tombstone GC:** \`d=1\` items older than 90 days auto-deleted in the same DB batch as any item write — no cron needed
- **Error toasts:** \`401\` → "Access to X was revoked" / \`404\` → "X was deleted" — both trigger full local teardown (syncMeta removed, poller stopped, list deleted from store)
- **Single share link model:** one editor token per list; owner can enable/disable sharing in one click; revoking kills access for all editors simultaneously
- **ShareSheet simplified:** no tabs, no per-token labels — QR + copy + "Stop sharing" + "Delete list"
- **ToastContainer** component (bottom-center, 5s auto-dismiss, a11y \`aria-live=assertive\`)
- **\`src/sync/cleanup.ts\`** — \`cleanupListLocally()\` shared between poll and queue with no circular dep

**Known edge case:** when an owner deletes a list, other devices get a 401 (tokens cascade-deleted) so they see "Access revoked" instead of "List deleted." Semantically imprecise but not a crash.

## Expected workflow

### First share (local-only list)
1. Open a list → tap the share icon
2. ShareSheet auto-provisions the list on the server, then immediately mints an editor share token
3. QR code appears — copy or native-share the link

### Re-sharing an already-synced list (sharing active)
1. Open ShareSheet → QR is shown immediately (share token already in localStorage)
2. Copy or share the link

### Re-sharing after sharing was stopped
1. Open ShareSheet → "Enable sharing" button is shown (no active share token)
2. Tap "Enable sharing" → new token minted → QR appears
3. Previous links no longer work; recipients need the new link

### Revoking access (stop sharing)
1. Open ShareSheet → tap "Stop sharing"
2. Server marks all editor tokens revoked in one call
3. ShareSheet transitions to "Enable sharing" state
4. Within one poll cycle (≤5s), all editor devices see "Access to X was revoked" toast and the list disappears locally

### Deleting the list
1. Open ShareSheet → tap "Delete shared list…" → confirm dialog
2. Owner device: list disappears, app navigates back to the lists screen
3. Editor devices: within one poll cycle, "Access to X was revoked" toast appears and list disappears locally

## Test plan

### Sharing — happy path
- [x] Open a local-only list → tap share → confirm provision happens and QR appears
- [x] On a second device/tab, open the join link — confirm the list loads with editor access
- [x] Close and reopen ShareSheet on owner — confirm QR is shown immediately (no re-provision)

### Stop sharing / revoke
- [x] With an editor connected, tap "Stop sharing" on owner → confirm no error
- [x] On editor device: wait up to 5s — confirm "Access to X was revoked" toast and list disappears
- [x] Owner: confirm ShareSheet now shows "Enable sharing" button
- [x] Tap "Enable sharing" — confirm new QR appears; old link no longer works for a fresh join attempt

### Delete list
- [x] Owner: "Delete shared list…" → confirm dialog → confirm deletion
- [x] Owner device: list gone, navigates to lists screen
- [x] Editor device: within 5s — toast appears, list disappears

### Tombstone GC
- [x] Delete an item on a synced list — confirm it disappears on both devices within one poll cycle

### Toasts
- [x] Revoke/delete scenarios above — confirm toast is dismissible via × before auto-dismiss

### Regression
- [x] Open ShareSheet on a synced list where sharing is active — QR loads without re-provisioning
- [x] Dark mode — confirm ShareSheet, toasts, and confirm dialog render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)