### PR TITLE
fix(lists): cascade delete/leave through sync layer

### DIFF
--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -104,3 +104,8 @@ export async function deleteList (listId: string): Promise<boolean> {
   cleanupListLocally(listId)
   return true
 }
+
+export function leaveList (listId: string): void {
+  stopPoller(listId)
+  cleanupListLocally(listId)
+}

--- a/src/views/Lists.vue
+++ b/src/views/Lists.vue
@@ -35,6 +35,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useListsStore } from '@/stores/lists'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import type List from '@/classes/List'
+import * as sync from '@/sync'
 
 const listsStore = useListsStore()
 const lists = computed(() => listsStore.lists)
@@ -44,9 +45,21 @@ function requestDelete (list: List): void {
   pendingDelete.value = list
 }
 
-function confirmDelete (): void {
-  if (pendingDelete.value) listsStore.deleteList(pendingDelete.value.id)
+async function confirmDelete (): Promise<void> {
+  if (!pendingDelete.value) return
+  const id = pendingDelete.value.id
   pendingDelete.value = null
+
+  const meta = sync.getMeta(id)
+  if (meta) {
+    if (meta.role === 'owner') {
+      await sync.deleteList(id)
+    } else {
+      sync.leaveList(id)
+    }
+  } else {
+    listsStore.deleteList(id)
+  }
 }
 
 function onModalOpenChange (value: boolean): void {

--- a/tests/unit/sync/owner-actions.spec.ts
+++ b/tests/unit/sync/owner-actions.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { enableSharing, disableSharing, deleteList } from '@/sync'
+import { enableSharing, disableSharing, deleteList, leaveList } from '@/sync'
 import { mintToken, revokeToken, deleteListRequest } from '@/sync/transport'
 import { stopPoller } from '@/sync/poll'
 import { cleanupListLocally } from '@/sync/cleanup'
@@ -118,6 +118,14 @@ describe('deleteList', () => {
 
     expect(await deleteList('list1')).toBe(true)
     expect(mDeleteListRequest).toHaveBeenCalledWith('list1', 'owner-tok')
+    expect(mStopPoller).toHaveBeenCalledWith('list1')
+    expect(mCleanupListLocally).toHaveBeenCalledWith('list1')
+  })
+})
+
+describe('leaveList', () => {
+  it('calls stopPoller and cleanupListLocally', () => {
+    leaveList('list1')
     expect(mStopPoller).toHaveBeenCalledWith('list1')
     expect(mCleanupListLocally).toHaveBeenCalledWith('list1')
   })

--- a/tests/unit/views/Lists.spec.js
+++ b/tests/unit/views/Lists.spec.js
@@ -4,6 +4,14 @@ import { createTestingPinia } from '@pinia/testing'
 import { useListsStore } from '@/stores/lists'
 import Lists from '@/views/Lists.vue'
 
+import * as sync from '@/sync'
+
+vi.mock('@/sync', () => ({
+  getMeta: vi.fn(),
+  deleteList: vi.fn(),
+  leaveList: vi.fn()
+}))
+
 const stubs = {
   RouterLink: { template: '<a><slot /></a>' },
   FontAwesomeIcon: { template: '<span />' }
@@ -23,6 +31,10 @@ describe('Lists.vue', () => {
       this.open = false
       this.dispatchEvent(new Event('close'))
     })
+    vi.mocked(sync.getMeta).mockReturnValue(null)
+    vi.mocked(sync.deleteList).mockResolvedValue(true)
+    vi.resetAllMocks()
+    vi.mocked(sync.getMeta).mockReturnValue(null)
   })
 
   it('shows empty-state message when there are no lists', () => {
@@ -50,12 +62,38 @@ describe('Lists.vue', () => {
     expect(modal.text()).toContain('Delete list?')
   })
 
-  it('calls deleteList when the modal Delete button is clicked', async () => {
+  it('calls store.deleteList for unsynced lists', async () => {
     const wrapper = mountLists([{ id: 'a1', n: 'Fruit', i: [] }])
     const store = useListsStore()
     await wrapper.find('.list__icon--delete').trigger('click')
     await wrapper.findAll('button').find(b => b.text() === 'Delete').trigger('click')
+    await wrapper.vm.$nextTick()
     expect(store.deleteList).toHaveBeenCalledWith('a1')
+    expect(wrapper.find('.confirm-modal').exists()).toBe(false)
+  })
+
+  it('calls sync.deleteList for owner synced lists', async () => {
+    vi.mocked(sync.getMeta).mockReturnValue({ role: 'owner', authToken: 'tok', lastVersion: 1 })
+    vi.mocked(sync.deleteList).mockResolvedValue(true)
+    const wrapper = mountLists([{ id: 'srv1', n: 'Shared', i: [] }])
+    const store = useListsStore()
+    await wrapper.find('.list__icon--delete').trigger('click')
+    await wrapper.findAll('button').find(b => b.text() === 'Delete').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(sync.deleteList).toHaveBeenCalledWith('srv1')
+    expect(store.deleteList).not.toHaveBeenCalled()
+    expect(wrapper.find('.confirm-modal').exists()).toBe(false)
+  })
+
+  it('calls sync.leaveList for editor synced lists', async () => {
+    vi.mocked(sync.getMeta).mockReturnValue({ role: 'editor', authToken: 'tok', lastVersion: 1 })
+    const wrapper = mountLists([{ id: 'srv2', n: 'Joined', i: [] }])
+    const store = useListsStore()
+    await wrapper.find('.list__icon--delete').trigger('click')
+    await wrapper.findAll('button').find(b => b.text() === 'Delete').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(sync.leaveList).toHaveBeenCalledWith('srv2')
+    expect(store.deleteList).not.toHaveBeenCalled()
     expect(wrapper.find('.confirm-modal').exists()).toBe(false)
   })
 


### PR DESCRIPTION
## Summary

- Deleting a synced list from the Lists view now routes through the sync layer instead of directly calling the store
- Owner delete calls `DELETE /api/lists/:id` so editors receive a 404 on their next poll and get cleaned up automatically
- Editor delete stops the poller and cleans up locally (no server-side operation available)
- Adds `leaveList` to `sync/index.ts` to encapsulate the editor cleanup path

## Test plan

- [ ] Unit: `owner-actions.spec.ts` — new `leaveList` describe block passes
- [ ] Unit: `Lists.spec.js` — new owner/editor/unsynced delete branches all pass; 163/163 suite green
- [ ] Manual: create a shared list, open it as an editor in a second browser, delete from owner's Lists view — editor's next poll should surface "List deleted"
- [ ] Manual: delete an unsynced list — behavior unchanged

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)