### PR TITLE
feat(theme): user-controlled dark/light/system mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
+<script>
+  (function () {
+    var m = localStorage.getItem('theme-mode');
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (m === 'dark' || (m !== 'light' && prefersDark)) {
+      document.documentElement.classList.add('dark');
+    }
+  })();
+</script>
 <noscript>
     <strong>We're sorry but Groceries List doesn't work properly without JavaScript enabled.
         Please enable it to continue.</strong>

--- a/src/App.vue
+++ b/src/App.vue
@@ -21,12 +21,14 @@ import AppHeader from '@/components/AppHeader.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import { useListsStore } from '@/stores/lists'
 import { useLiveRegion } from '@/composables/useLiveRegion'
+import { useTheme } from '@/composables/useTheme'
 import * as sync from '@/sync'
 
 const router = useRouter()
 const listsStore = useListsStore()
 const loaded = ref(false)
 const { message: liveMessage, announce } = useLiveRegion()
+const { init: initTheme } = useTheme()
 
 async function handleJoinFragment () {
   const m = /^#join=([^.]+)\.(.+)$/.exec(window.location.hash)
@@ -49,6 +51,7 @@ async function handleJoinFragment () {
 }
 
 onMounted(async () => {
+  initTheme()
   listsStore.init()
   loaded.value = true
   sync.startPolling()

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
   --color-gl-lightblue: #BEC4E5;

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -11,9 +11,37 @@
           <span>New List</span>
         </router-link>
       </nav>
+      <button
+        class="header__theme-toggle"
+        :aria-label="`Switch to ${nextMode} mode`"
+        :aria-pressed="false"
+        @click="cycleMode"
+      >
+        <font-awesome-icon :icon="modeIcon"/>
+      </button>
     </div>
   </header>
 </template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useTheme } from '@/composables/useTheme'
+
+const { mode, cycleMode } = useTheme()
+
+const CYCLE = ['light', 'dark', 'system'] as const
+
+const modeIcon = computed(() => {
+  if (mode.value === 'dark') return 'moon'
+  if (mode.value === 'light') return 'sun'
+  return 'desktop'
+})
+
+const nextMode = computed(() => {
+  const idx = CYCLE.indexOf(mode.value)
+  return CYCLE[(idx + 1) % CYCLE.length]
+})
+</script>
 
 <style lang="scss">
 @reference "../assets/main.css";
@@ -44,6 +72,13 @@
     &__icon {
       @apply mr-2 text-lg;
     }
+  }
+
+  &__theme-toggle {
+    @apply ml-4 flex items-center justify-center w-9 h-9 rounded-full;
+    @apply text-gl-darkblue hover:bg-gl-lightgray focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gl-blueberry;
+    @apply dark:text-gray-200 dark:hover:bg-gl-muted-blue;
+    flex-shrink: 0;
   }
 }
 </style>

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -1,0 +1,43 @@
+import { ref, readonly } from 'vue'
+
+export type ThemeMode = 'light' | 'dark' | 'system'
+
+const STORAGE_KEY = 'theme-mode'
+const CYCLE: ThemeMode[] = ['light', 'dark', 'system']
+
+const mode = ref<ThemeMode>('system')
+let mq: MediaQueryList | null = null
+
+function apply (m: ThemeMode) {
+  const isDark = m === 'dark' || (m === 'system' && (mq?.matches ?? false))
+  document.documentElement.classList.toggle('dark', isDark)
+}
+
+function onMediaChange (e: MediaQueryListEvent) {
+  if (mode.value === 'system') {
+    document.documentElement.classList.toggle('dark', e.matches)
+  }
+}
+
+function setMode (m: ThemeMode) {
+  mode.value = m
+  localStorage.setItem(STORAGE_KEY, m)
+  apply(m)
+}
+
+function cycleMode () {
+  const idx = CYCLE.indexOf(mode.value)
+  setMode(CYCLE[(idx + 1) % CYCLE.length])
+}
+
+function init () {
+  mq = window.matchMedia('(prefers-color-scheme: dark)')
+  mq.addEventListener('change', onMediaChange)
+  const stored = localStorage.getItem(STORAGE_KEY) as ThemeMode | null
+  mode.value = stored && CYCLE.includes(stored) ? stored : 'system'
+  apply(mode.value)
+}
+
+export function useTheme () {
+  return { mode: readonly(mode), setMode, cycleMode, init }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,13 +6,16 @@ import './assets/main.css'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import {
   faCheck,
+  faDesktop,
+  faMoon,
   faPlusSquare,
   faShareNodes,
+  faSun,
   faTimesCircle
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
-library.add(faPlusSquare, faTimesCircle, faCheck, faShareNodes)
+library.add(faPlusSquare, faTimesCircle, faCheck, faShareNodes, faSun, faMoon, faDesktop)
 
 const app = createApp(App)
   .use(createPinia())

--- a/tests/unit/composables/useTheme.spec.ts
+++ b/tests/unit/composables/useTheme.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+let mockMatches = false
+const mockAddEventListener = vi.fn()
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: mockMatches,
+    media: query,
+    addEventListener: mockAddEventListener,
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  }))
+})
+
+async function freshTheme () {
+  vi.resetModules()
+  const { useTheme } = await import('@/composables/useTheme')
+  return useTheme()
+}
+
+describe('useTheme', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.classList.remove('dark')
+    mockMatches = false
+    mockAddEventListener.mockClear()
+  })
+
+  describe('init', () => {
+    it('defaults to system when no localStorage entry', async () => {
+      const { mode, init } = await freshTheme()
+      init()
+      expect(mode.value).toBe('system')
+    })
+
+    it('restores persisted light mode', async () => {
+      localStorage.setItem('theme-mode', 'light')
+      const { mode, init } = await freshTheme()
+      init()
+      expect(mode.value).toBe('light')
+      expect(document.documentElement.classList.contains('dark')).toBe(false)
+    })
+
+    it('restores persisted dark mode and adds .dark class', async () => {
+      localStorage.setItem('theme-mode', 'dark')
+      const { mode, init } = await freshTheme()
+      init()
+      expect(mode.value).toBe('dark')
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+    })
+
+    it('ignores invalid localStorage values and falls back to system', async () => {
+      localStorage.setItem('theme-mode', 'garbage')
+      const { mode, init } = await freshTheme()
+      init()
+      expect(mode.value).toBe('system')
+    })
+
+    it('applies dark class in system mode when OS prefers dark', async () => {
+      mockMatches = true
+      const { init } = await freshTheme()
+      init()
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+    })
+
+    it('registers a change listener on the media query', async () => {
+      const { init } = await freshTheme()
+      init()
+      expect(mockAddEventListener).toHaveBeenCalledWith('change', expect.any(Function))
+    })
+  })
+
+  describe('setMode', () => {
+    it('switches to dark and persists', async () => {
+      const { mode, setMode, init } = await freshTheme()
+      init()
+      setMode('dark')
+      expect(mode.value).toBe('dark')
+      expect(localStorage.getItem('theme-mode')).toBe('dark')
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+    })
+
+    it('switches to light and removes .dark class', async () => {
+      document.documentElement.classList.add('dark')
+      const { mode, setMode, init } = await freshTheme()
+      init()
+      setMode('light')
+      expect(mode.value).toBe('light')
+      expect(document.documentElement.classList.contains('dark')).toBe(false)
+    })
+
+    it('switches to system and reflects OS preference', async () => {
+      mockMatches = true
+      const { mode, setMode, init } = await freshTheme()
+      init()
+      setMode('light')
+      expect(document.documentElement.classList.contains('dark')).toBe(false)
+      setMode('system')
+      expect(mode.value).toBe('system')
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+    })
+  })
+
+  describe('cycleMode', () => {
+    it('cycles light → dark → system → light', async () => {
+      const { mode, cycleMode, init } = await freshTheme()
+      init()
+      // starts at system
+      cycleMode() // system → light
+      expect(mode.value).toBe('light')
+      cycleMode() // light → dark
+      expect(mode.value).toBe('dark')
+      cycleMode() // dark → system
+      expect(mode.value).toBe('system')
+      cycleMode() // system → light
+      expect(mode.value).toBe('light')
+    })
+
+    it('persists each cycled mode to localStorage', async () => {
+      const { cycleMode, init } = await freshTheme()
+      init()
+      cycleMode()
+      expect(localStorage.getItem('theme-mode')).toBe('light')
+      cycleMode()
+      expect(localStorage.getItem('theme-mode')).toBe('dark')
+      cycleMode()
+      expect(localStorage.getItem('theme-mode')).toBe('system')
+    })
+  })
+})

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -1,0 +1,11 @@
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  configurable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -25,6 +25,7 @@ export default defineConfig({
   resolve: { alias: { '@': path.resolve(__dirname, 'src') } },
   test: {
     include: ['tests/unit/**/*.spec.{js,ts}'],
+    setupFiles: ['tests/unit/setup.ts'],
     environment: 'jsdom',
     globals: true,
     coverage: {


### PR DESCRIPTION
Closes #25

## Summary
- `useTheme` composable (singleton) exposes `mode`, `setMode`, `cycleMode`, and `init`; listens to `matchMedia` changes while in `system` mode
- Switched Tailwind v4 to class-based dark mode via `@custom-variant dark (&:where(.dark, .dark *))`
- Inline FOUC-prevention script in `index.html` applies `.dark` on `<html>` before Vue mounts
- Icon-only toggle in `AppHeader` cycles light → dark → system with a dynamic `aria-label`

## Test plan
- [x] Toggle persists across page reloads
- [x] `system` mode tracks live OS changes (toggle system dark mode while page is open)
- [x] Existing dark styling visually unchanged when system theme is dark
- [x] All 174 unit tests pass (`npx vitest run`)
- [x] Lint clean (`npx eslint src/ tests/unit/`)
- [x] Build succeeds (`npx vite build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)