### PR TITLE
fix(api): validate items + cap payload size on mutation handlers

### DIFF
--- a/functions/api/_shared/handlers.ts
+++ b/functions/api/_shared/handlers.ts
@@ -1,6 +1,7 @@
 import type { ItemRow, ListRow, TokenRow } from './types'
 import { generateUlid, generateToken } from './ulid'
 import { hashToken, authenticate } from './auth'
+import { LIMITS, readJsonBody, validateItem } from './validate'
 
 const TOMBSTONE_TTL_MS = 90 * 24 * 60 * 60 * 1000
 
@@ -13,24 +14,12 @@ export async function handleUpsertItem (
   const auth = await authenticate(db, request, listId)
   if (auth instanceof Response) return auth
 
-  let body: { n?: unknown; q?: unknown; c?: unknown; u?: unknown; d?: unknown }
-  try {
-    body = await request.json() as typeof body
-  } catch {
-    return Response.json({ error: 'Invalid JSON' }, { status: 400 })
-  }
+  const parsed = await readJsonBody<Record<string, unknown>>(request)
+  if (!parsed.ok) return Response.json({ error: parsed.error }, { status: parsed.status })
 
-  if (typeof body.n !== 'string' || typeof body.u !== 'number') {
-    return Response.json({ error: 'n and u required' }, { status: 400 })
-  }
-
-  const incoming: ItemRow = {
-    id: itemId,
-    n: body.n,
-    q: typeof body.q === 'string' ? body.q : '',
-    c: typeof body.c === 'number' ? body.c : 0,
-    u: body.u,
-    d: typeof body.d === 'number' ? body.d : 0
+  const incoming = validateItem({ ...parsed.body, id: itemId })
+  if (incoming === null) {
+    return Response.json({ error: 'invalid item' }, { status: 400 })
   }
 
   const existing = await db.prepare(
@@ -62,15 +51,15 @@ export async function handlePatchList (
   const auth = await authenticate(db, request, listId)
   if (auth instanceof Response) return auth
 
-  let body: { name?: unknown; u?: unknown }
-  try {
-    body = await request.json() as typeof body
-  } catch {
-    return Response.json({ error: 'Invalid JSON' }, { status: 400 })
-  }
+  const parsed = await readJsonBody<{ name?: unknown; u?: unknown }>(request)
+  if (!parsed.ok) return Response.json({ error: parsed.error }, { status: parsed.status })
+  const body = parsed.body
 
-  if (typeof body.name !== 'string' || typeof body.u !== 'number') {
-    return Response.json({ error: 'name and u required' }, { status: 400 })
+  if (typeof body.name !== 'string' || body.name.length === 0 || body.name.length > LIMITS.listNameMax) {
+    return Response.json({ error: 'name required' }, { status: 400 })
+  }
+  if (typeof body.u !== 'number' || !Number.isFinite(body.u) || body.u < 0) {
+    return Response.json({ error: 'u required' }, { status: 400 })
   }
 
   const list = await db.prepare(
@@ -93,18 +82,25 @@ export async function handlePatchList (
 }
 
 export async function handleProvision (db: D1Database, request: Request): Promise<Response> {
-  let body: { name?: unknown; items?: unknown }
-  try {
-    body = await request.json() as { name?: unknown; items?: unknown }
-  } catch {
-    return Response.json({ error: 'Invalid JSON' }, { status: 400 })
-  }
+  const parsed = await readJsonBody<{ name?: unknown; items?: unknown }>(request)
+  if (!parsed.ok) return Response.json({ error: parsed.error }, { status: parsed.status })
+  const body = parsed.body
 
-  if (!body.name || typeof body.name !== 'string') {
+  if (typeof body.name !== 'string' || body.name.length === 0 || body.name.length > LIMITS.listNameMax) {
     return Response.json({ error: 'name required' }, { status: 400 })
   }
 
-  const items = Array.isArray(body.items) ? body.items as ItemRow[] : []
+  const rawItems = Array.isArray(body.items) ? body.items : []
+  if (rawItems.length > LIMITS.itemsMax) {
+    return Response.json({ error: 'too many items' }, { status: 400 })
+  }
+  const items: ItemRow[] = []
+  for (const raw of rawItems) {
+    const item = validateItem(raw)
+    if (item === null) return Response.json({ error: 'invalid item' }, { status: 400 })
+    items.push(item)
+  }
+
   const listId = generateUlid()
   const authToken = generateToken()
   const tokenHash = await hashToken(authToken)
@@ -117,10 +113,10 @@ export async function handleProvision (db: D1Database, request: Request): Promis
     db.prepare(
       'INSERT INTO list_tokens (token_hash, list_id, role, created_at) VALUES (?, ?, ?, ?)'
     ).bind(tokenHash, listId, 'owner', now),
-    ...items.map((item: ItemRow) =>
+    ...items.map((item) =>
       db.prepare(
         'INSERT INTO items (list_id, id, n, q, c, u, d) VALUES (?, ?, ?, ?, ?, ?, ?)'
-      ).bind(listId, item.id, item.n, item.q, item.c ?? 0, item.u ?? now, item.d ?? 0)
+      ).bind(listId, item.id, item.n, item.q, item.c, item.u, item.d)
     )
   ])
 
@@ -168,14 +164,11 @@ export async function handleJoin (
   request: Request,
   listId: string
 ): Promise<Response> {
-  let body: { token?: unknown }
-  try {
-    body = await request.json() as { token?: unknown }
-  } catch {
-    return Response.json({ error: 'Invalid JSON' }, { status: 400 })
-  }
+  const parsed = await readJsonBody<{ token?: unknown }>(request)
+  if (!parsed.ok) return Response.json({ error: parsed.error }, { status: parsed.status })
+  const body = parsed.body
 
-  if (!body.token || typeof body.token !== 'string') {
+  if (!body.token || typeof body.token !== 'string' || body.token.length > 256) {
     return Response.json({ error: 'token required' }, { status: 400 })
   }
 

--- a/functions/api/_shared/validate.ts
+++ b/functions/api/_shared/validate.ts
@@ -1,0 +1,60 @@
+import type { ItemRow } from './types'
+
+export const LIMITS = {
+  itemIdMax: 64,
+  itemNameMax: 500,
+  itemQtyMax: 100,
+  listNameMax: 500,
+  itemsMax: 1000,
+  bodyBytesMax: 1_048_576
+} as const
+
+const MAX_TIMESTAMP = 4_102_444_800_000
+
+export function validateItem (raw: unknown): ItemRow | null {
+  if (raw === null || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+
+  if (typeof r.id !== 'string' || r.id.length === 0 || r.id.length > LIMITS.itemIdMax) return null
+  if (typeof r.n !== 'string' || r.n.length > LIMITS.itemNameMax) return null
+  if (typeof r.u !== 'number' || !Number.isFinite(r.u) || r.u < 0 || r.u > MAX_TIMESTAMP) return null
+
+  const q = r.q === undefined ? '' : r.q
+  if (typeof q !== 'string' || q.length > LIMITS.itemQtyMax) return null
+
+  const c = r.c === undefined ? 0 : r.c
+  if (c !== 0 && c !== 1) return null
+
+  const d = r.d === undefined ? 0 : r.d
+  if (d !== 0 && d !== 1) return null
+
+  return { id: r.id, n: r.n, q, c, u: r.u, d }
+}
+
+export async function readJsonBody<T = unknown> (request: Request): Promise<
+  { ok: true; body: T } | { ok: false; status: number; error: string }
+> {
+  const len = request.headers.get('content-length')
+  if (len !== null) {
+    const n = Number(len)
+    if (Number.isFinite(n) && n > LIMITS.bodyBytesMax) {
+      return { ok: false, status: 413, error: 'Payload Too Large' }
+    }
+  }
+
+  let text: string
+  try {
+    text = await request.text()
+  } catch {
+    return { ok: false, status: 400, error: 'Invalid body' }
+  }
+  if (text.length > LIMITS.bodyBytesMax) {
+    return { ok: false, status: 413, error: 'Payload Too Large' }
+  }
+
+  try {
+    return { ok: true, body: JSON.parse(text) as T }
+  } catch {
+    return { ok: false, status: 400, error: 'Invalid JSON' }
+  }
+}

--- a/tests/integration/api/lists.spec.ts
+++ b/tests/integration/api/lists.spec.ts
@@ -94,6 +94,60 @@ describe('POST /api/lists', () => {
     const res = await handleProvision(db, req)
     expect(res.status).toBe(400)
   })
+
+  it('returns 400 when an item has wrong types', async () => {
+    const cases: object[] = [
+      { id: 'abc12345', n: 'Milk', q: 1, c: 0, u: 1000, d: 0 }, // q non-string
+      { id: 'abc12345', n: 'Milk', q: '1', c: 'yes', u: 1000, d: 0 }, // c non-number
+      { id: 'abc12345', n: 'Milk', q: '1', c: 0, u: '1000', d: 0 }, // u non-number
+      { id: 'abc12345', n: 'Milk', q: '1', c: 0, u: 1000, d: 2 }, // d out of range
+      { id: '', n: 'Milk', q: '1', c: 0, u: 1000, d: 0 }, // id empty
+      { n: 'Milk', q: '1', c: 0, u: 1000, d: 0 } // id missing
+    ]
+    for (const item of cases) {
+      const req = new Request('http://localhost/api/lists', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'X', items: [item] })
+      })
+      const res = await handleProvision(db, req)
+      expect(res.status).toBe(400)
+    }
+  })
+
+  it('returns 400 when an item name exceeds max length', async () => {
+    const item = { id: 'abc12345', n: 'a'.repeat(501), q: '', c: 0, u: 1000, d: 0 }
+    const req = new Request('http://localhost/api/lists', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'X', items: [item] })
+    })
+    const res = await handleProvision(db, req)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when items array exceeds cap', async () => {
+    const items = Array.from({ length: 1001 }, (_, i) => ({
+      id: `id${i.toString().padStart(6, '0')}`, n: 'x', q: '', c: 0, u: 1, d: 0
+    }))
+    const req = new Request('http://localhost/api/lists', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'X', items })
+    })
+    const res = await handleProvision(db, req)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 413 when content-length exceeds cap', async () => {
+    const req = new Request('http://localhost/api/lists', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': String(2 * 1024 * 1024) },
+      body: JSON.stringify({ name: 'X', items: [] })
+    })
+    const res = await handleProvision(db, req)
+    expect(res.status).toBe(413)
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -356,6 +410,31 @@ describe('POST /api/lists/:id/items/:itemId', () => {
   it('returns 400 when n is missing', async () => {
     const { id, authToken } = await setup()
     const res = await handleUpsertItem(db, upsertReq(id, 'item0001', authToken, { q: '1', u: 1000 }), id, 'item0001')
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when q is wrong type', async () => {
+    const { id, authToken } = await setup()
+    const res = await handleUpsertItem(db, upsertReq(id, 'item0001', authToken, { n: 'Milk', q: 5, c: 0, u: 1000, d: 0 }), id, 'item0001')
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when c is out of range', async () => {
+    const { id, authToken } = await setup()
+    const res = await handleUpsertItem(db, upsertReq(id, 'item0001', authToken, { n: 'Milk', q: '1', c: 2, u: 1000, d: 0 }), id, 'item0001')
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when n exceeds max length', async () => {
+    const { id, authToken } = await setup()
+    const res = await handleUpsertItem(db, upsertReq(id, 'item0001', authToken, { n: 'a'.repeat(501), q: '', c: 0, u: 1000, d: 0 }), id, 'item0001')
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when itemId path param exceeds max length', async () => {
+    const { id, authToken } = await setup()
+    const longId = 'a'.repeat(65)
+    const res = await handleUpsertItem(db, upsertReq(id, longId, authToken, { n: 'Milk', q: '', c: 0, u: 1000, d: 0 }), id, longId)
     expect(res.status).toBe(400)
   })
 


### PR DESCRIPTION
## Summary
- New `validate.ts` module: `validateItem` enforces per-field types, lengths, and ranges; `readJsonBody` caps payloads at 1 MB (Content-Length + post-read length check).
- `handleProvision` rejects malformed items, caps `items` at 1000, and validates list `name` length.
- `handleUpsertItem` runs the same validator (the URL `itemId` is the canonical id), so bad `q`/`c`/`d` now 400 instead of silently defaulting; oversized `itemId` path params also rejected.
- `handlePatchList` enforces non-empty bounded `name` and finite non-negative `u`. `handleJoin` caps token length at 256.
- Integration tests cover bad item types, oversized strings, items-cap overflow, and oversized body.

Limits: `id` ≤64, `n`/list `name` ≤500, `q` ≤100, `c`/`d` ∈ {0,1}, `u` finite ≥0, items ≤1000, body ≤1 MB.

Closes #47.

## Test plan
- [x] `npm run test:integration` — 45 tests pass (6 new validation cases)
- [x] `npm run test:unit` — 175 tests pass
- [x] `npm run lint` clean
- [x] `npm run type-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)