### PR TITLE
fix(lint): include .ts in lint-staged glob (#52)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
     "node": ">=22.22.1 <23"
   },
   "lint-staged": {
-    "*.{js,vue}": "eslint --fix"
+    "*.{js,ts,vue}": "eslint --fix"
   }
 }


### PR DESCRIPTION
## Summary
- Add `ts` to the `lint-staged` glob in `package.json` so `eslint --fix` runs on staged TypeScript files at commit time.
- Restores pre-commit safety net for `src/sync/`, `functions/`, and newer `*.spec.ts` files that were previously only checked in CI.

Closes #52.

## Test plan
- [x] `npx eslint functions/**/*.ts` runs cleanly with existing config
- [x] Stage a deliberately broken `.ts` file and confirm the pre-commit hook flags it

🤖 Generated with [Claude Code](https://claude.com/claude-code)