### PR TITLE
chore(sync): remove dead patchList sync path (#35)

### DIFF
--- a/functions/api/_shared/handlers.ts
+++ b/functions/api/_shared/handlers.ts
@@ -43,44 +43,6 @@ export async function handleUpsertItem (
   return Response.json({ item: incoming })
 }
 
-export async function handlePatchList (
-  db: D1Database,
-  request: Request,
-  listId: string
-): Promise<Response> {
-  const auth = await authenticate(db, request, listId)
-  if (auth instanceof Response) return auth
-
-  const parsed = await readJsonBody<{ name?: unknown; u?: unknown }>(request)
-  if (!parsed.ok) return Response.json({ error: parsed.error }, { status: parsed.status })
-  const body = parsed.body
-
-  if (typeof body.name !== 'string' || body.name.length === 0 || body.name.length > LIMITS.listNameMax) {
-    return Response.json({ error: 'name required' }, { status: 400 })
-  }
-  if (typeof body.u !== 'number' || !Number.isFinite(body.u) || body.u < 0) {
-    return Response.json({ error: 'u required' }, { status: 400 })
-  }
-
-  const list = await db.prepare(
-    'SELECT id, name, u, version FROM lists WHERE id = ?'
-  ).bind(listId).first<ListRow>()
-
-  if (!list) return Response.json({ error: 'Not Found' }, { status: 404 })
-
-  if (list.u > body.u) {
-    return Response.json({ name: list.name, u: list.u })
-  }
-
-  await db.batch([
-    db.prepare(
-      'UPDATE lists SET name = ?, u = ?, version = version + 1 WHERE id = ?'
-    ).bind(body.name, body.u, listId)
-  ])
-
-  return Response.json({ name: body.name, u: body.u })
-}
-
 export async function handleProvision (db: D1Database, request: Request): Promise<Response> {
   const parsed = await readJsonBody<{ name?: unknown; items?: unknown }>(request)
   if (!parsed.ok) return Response.json({ error: parsed.error }, { status: parsed.status })

--- a/functions/api/lists/[id]/index.ts
+++ b/functions/api/lists/[id]/index.ts
@@ -1,12 +1,9 @@
 import type { PagesFunction } from '@cloudflare/workers-types'
 import type { Env } from '../../_shared/types'
-import { handlePoll, handlePatchList, handleDeleteList } from '../../_shared/handlers'
+import { handlePoll, handleDeleteList } from '../../_shared/handlers'
 
 export const onRequestGet: PagesFunction<Env> = ({ request, env, params }) =>
   handlePoll(env.DB, request, params.id as string)
-
-export const onRequestPatch: PagesFunction<Env> = ({ request, env, params }) =>
-  handlePatchList(env.DB, request, params.id as string)
 
 export const onRequestDelete: PagesFunction<Env> = ({ request, env, params }) =>
   handleDeleteList(env.DB, request, params.id as string)

--- a/src/sync/queue.ts
+++ b/src/sync/queue.ts
@@ -1,10 +1,10 @@
 import { useListsStore } from '@/stores/lists'
 import { useToastStore } from '@/stores/toast'
 import { getMeta } from './storage'
-import { upsertItem, patchList } from './transport'
+import { upsertItem } from './transport'
 import { reconcileServerItem } from './reconcile'
 import { cleanupListLocally } from './cleanup'
-import type { Op, UpsertItemResponse, PatchListResponse } from './types'
+import type { Op } from './types'
 
 const QUEUE_KEY = 'pendingOps'
 const MAX_BACKOFF_MS = 60_000
@@ -62,21 +62,11 @@ async function flush (): Promise<void> {
       continue
     }
 
-    const result = op.kind === 'upsertItem'
-      ? await upsertItem(op.listId, op.item.id, meta.authToken, op.item)
-      : await patchList(op.listId, meta.authToken, op.name, op.u)
+    const result = await upsertItem(op.listId, op.item.id, meta.authToken, op.item)
 
     if (result.ok) {
       backoffMs = 1_000
-      if (op.kind === 'upsertItem') {
-        reconcileServerItem(op.listId, (result.data as UpsertItemResponse).item)
-      } else {
-        const store = useListsStore()
-        const list = store.getListFromId(op.listId)
-        if (list) {
-          list.n = (result.data as PatchListResponse).name
-        }
-      }
+      reconcileServerItem(op.listId, result.data.item)
       saveQueue(loadQueue().slice(1))
     } else if (
       result.error.kind === 'unauthorized' ||

--- a/src/sync/transport.ts
+++ b/src/sync/transport.ts
@@ -1,4 +1,4 @@
-import type { TransportResult, ProvisionResponse, JoinResponse, PollPayload, ItemPayload, UpsertItemResponse, PatchListResponse, MintTokenResponse } from './types'
+import type { TransportResult, ProvisionResponse, JoinResponse, PollPayload, ItemPayload, UpsertItemResponse, MintTokenResponse } from './types'
 
 function normError (status: number) {
   if (status === 401) return { kind: 'unauthorized' as const }
@@ -73,28 +73,6 @@ export async function upsertItem (
     })
     if (!res.ok) return { ok: false, error: normError(res.status) }
     return { ok: true, data: await res.json() as UpsertItemResponse }
-  } catch {
-    return { ok: false, error: { kind: 'network' } }
-  }
-}
-
-export async function patchList (
-  listId: string,
-  authToken: string,
-  name: string,
-  u: number
-): Promise<TransportResult<PatchListResponse>> {
-  try {
-    const res = await fetch(`/api/lists/${listId}`, {
-      method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${authToken}`
-      },
-      body: JSON.stringify({ name, u })
-    })
-    if (!res.ok) return { ok: false, error: normError(res.status) }
-    return { ok: true, data: await res.json() as PatchListResponse }
   } catch {
     return { ok: false, error: { kind: 'network' } }
   }

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -40,11 +40,6 @@ export interface UpsertItemResponse {
   item: ItemPayload
 }
 
-export interface PatchListResponse {
-  name: string
-  u: number
-}
-
 export interface MintTokenResponse {
   token: string
 }
@@ -55,14 +50,7 @@ export interface UpsertItemOp {
   item: ItemPayload
 }
 
-export interface PatchListOp {
-  kind: 'patchList'
-  listId: string
-  name: string
-  u: number
-}
-
-export type Op = UpsertItemOp | PatchListOp
+export type Op = UpsertItemOp
 
 export type SyncError =
   | { kind: 'unauthorized' }

--- a/tests/integration/api/lists.spec.ts
+++ b/tests/integration/api/lists.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import { Miniflare } from 'miniflare'
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
-import { handleProvision, handleJoin, handlePoll, handleUpsertItem, handlePatchList, handleMintToken, handleRevokeToken, handleDeleteList } from '../../../functions/api/_shared/handlers'
+import { handleProvision, handleJoin, handlePoll, handleUpsertItem, handleMintToken, handleRevokeToken, handleDeleteList } from '../../../functions/api/_shared/handlers'
 
 const schema = readFileSync(resolve(__dirname, '../../../schema.sql'), 'utf-8')
 
@@ -445,73 +445,6 @@ describe('POST /api/lists/:id/items/:itemId', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ n: 'Milk', q: '1', c: 0, u: 1000, d: 0 })
     }), id, 'item0001')
-    expect(res.status).toBe(401)
-  })
-})
-
-// ---------------------------------------------------------------------------
-// PATCH /api/lists/:id (rename)
-// ---------------------------------------------------------------------------
-
-describe('PATCH /api/lists/:id', () => {
-  async function setup () {
-    const req = new Request('http://localhost/api/lists', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: 'Original Name', items: [] })
-    })
-    return handleProvision(db, req).then(r => r.json() as Promise<{ id: string; authToken: string }>)
-  }
-
-  function patchReq (listId: string, token: string, body: object) {
-    return new Request(`http://localhost/api/lists/${listId}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-      body: JSON.stringify(body)
-    })
-  }
-
-  it('renames the list and returns canonical', async () => {
-    const { id, authToken } = await setup()
-    const res = await handlePatchList(db, patchReq(id, authToken, { name: 'New Name', u: 5000 }), id)
-    expect(res.status).toBe(200)
-    const body = await res.json() as { name: string; u: number }
-    expect(body.name).toBe('New Name')
-    expect(body.u).toBe(5000)
-  })
-
-  it('increments list version on rename', async () => {
-    const { id, authToken } = await setup()
-    await handlePatchList(db, patchReq(id, authToken, { name: 'New Name', u: 5000 }), id)
-    const body = await handlePoll(db, new Request(`http://localhost/api/lists/${id}?since=0`, { headers: { Authorization: `Bearer ${authToken}` } }), id)
-      .then(r => r.json() as Promise<{ version: number; name: string }>)
-    expect(body.version).toBe(2)
-    expect(body.name).toBe('New Name')
-  })
-
-  it('returns existing canonical on stale rename', async () => {
-    const { id, authToken } = await setup()
-    await handlePatchList(db, patchReq(id, authToken, { name: 'New Name', u: 5000 }), id)
-    const res = await handlePatchList(db, patchReq(id, authToken, { name: 'Stale Name', u: 3000 }), id)
-    expect(res.status).toBe(200)
-    const body = await res.json() as { name: string; u: number }
-    expect(body.name).toBe('New Name')
-    expect(body.u).toBe(5000)
-  })
-
-  it('returns 400 when name is missing', async () => {
-    const { id, authToken } = await setup()
-    const res = await handlePatchList(db, patchReq(id, authToken, { u: 5000 }), id)
-    expect(res.status).toBe(400)
-  })
-
-  it('returns 401 without a token', async () => {
-    const { id } = await setup()
-    const res = await handlePatchList(db, new Request(`http://localhost/api/lists/${id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: 'Hacked', u: 9999 })
-    }), id)
     expect(res.status).toBe(401)
   })
 })

--- a/tests/unit/sync/queue.spec.ts
+++ b/tests/unit/sync/queue.spec.ts
@@ -14,8 +14,7 @@ vi.mock('@/sync/storage', () => ({
 }))
 
 vi.mock('@/sync/transport', () => ({
-  upsertItem: vi.fn(),
-  patchList: vi.fn()
+  upsertItem: vi.fn()
 }))
 
 vi.mock('@/sync/reconcile', () => ({


### PR DESCRIPTION
## Summary
- Resolves #35 by deleting the unreachable `patchList` sync path: op type, transport function, queue branch, PATCH route, and `handlePatchList` server handler.
- Picked option 2 (delete) over option 1 (build a list-rename UI): no rename UI exists today, live-sync MVP is in cleanup mode, and deletion also closes the secondary concern about `handlePatchList` trusting client-supplied `u` for conflict resolution.

## Changes
- `src/sync/types.ts` — drop `PatchListOp`, `PatchListResponse`; `Op = UpsertItemOp`.
- `src/sync/transport.ts` — drop `patchList()`.
- `src/sync/queue.ts` — single-kind flush (no branching, no patchList result handling).
- `functions/api/_shared/handlers.ts` — drop `handlePatchList`.
- `functions/api/lists/[id]/index.ts` — drop `onRequestPatch` route.
- Tests updated: removed PATCH integration suite, removed `patchList` mock entry from queue unit test.

Schema columns (`lists.u`, `lists.name`) and the poll handler's `name`/`nameUpdatedAt` defensive plumbing are left in place — they're harmless without a writer and dropping them would push beyond the issue's scope.

## Test plan
- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run test:unit` — 175 passed
- [x] `npm run test:integration` — 40 passed
- [x] `npm run build`
- [x] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)