### PR TITLE
fix(theme): guard useTheme init against re-registration

### DIFF
--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -7,6 +7,7 @@ const CYCLE: ThemeMode[] = ['light', 'dark', 'system']
 
 const mode = ref<ThemeMode>('system')
 let mq: MediaQueryList | null = null
+let initialized = false
 
 function apply (m: ThemeMode) {
   const isDark = m === 'dark' || (m === 'system' && (mq?.matches ?? false))
@@ -31,6 +32,8 @@ function cycleMode () {
 }
 
 function init () {
+  if (initialized) return
+  initialized = true
   mq = window.matchMedia('(prefers-color-scheme: dark)')
   mq.addEventListener('change', onMediaChange)
   const stored = localStorage.getItem(STORAGE_KEY) as ThemeMode | null

--- a/tests/unit/composables/useTheme.spec.ts
+++ b/tests/unit/composables/useTheme.spec.ts
@@ -70,6 +70,14 @@ describe('useTheme', () => {
       init()
       expect(mockAddEventListener).toHaveBeenCalledWith('change', expect.any(Function))
     })
+
+    it('is idempotent: repeated init() calls do not re-register the listener', async () => {
+      const { init } = await freshTheme()
+      init()
+      init()
+      init()
+      expect(mockAddEventListener).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('setMode', () => {


### PR DESCRIPTION
## Summary
- Add module-level `initialized` flag in `useTheme` so repeated `init()` calls are no-ops, preventing stacked `matchMedia` change listeners under HMR or future re-mount.
- Add idempotency test asserting `addEventListener` is called exactly once across multiple `init()` invocations.

Closes #41

## Test plan
- [x] `npx vitest run tests/unit/composables/useTheme.spec.ts` — 12 pass (incl. new idempotency test)
- [x] `npx eslint` on changed files — clean
- [x] `npx vue-tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)