### PR TITLE
refactor(lists): return created list from createList (#57)

### DIFF
--- a/src/stores/lists.ts
+++ b/src/stores/lists.ts
@@ -37,6 +37,7 @@ export const useListsStore = defineStore('lists', () => {
   function createList (list: List) {
     lists.value.push(list)
     persist()
+    return list
   }
 
   function deleteList (id: string) {

--- a/src/views/New.vue
+++ b/src/views/New.vue
@@ -30,10 +30,10 @@ const name = ref<string | null>(null)
 const newListName = ref<HTMLInputElement | null>(null)
 
 function createList (): void {
-  listsStore.createList(new List(name.value!, []))
+  const list = listsStore.createList(new List(name.value!, []))
   router.push({
     name: 'List',
-    params: { id: listsStore.lists.at(-1)!.id }
+    params: { id: list.id }
   })
 }
 


### PR DESCRIPTION
## Summary
- `listsStore.createList` now returns the created list.
- `New.vue` uses the returned `list.id` instead of `lists.at(-1)!.id`.

Closes #57.

## Why
`lists.at(-1)` assumes the just-pushed list is always last. Any future change to `createList` ordering (insert at index 0, server-pushed list interleaving, etc.) would silently navigate to the wrong list. Returning the list eliminates the assumption.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test:unit` (176 passing)
- [x] Manual: create a new list in dev, confirm navigation lands on its detail view

🤖 Generated with [Claude Code](https://claude.com/claude-code)