### PR TITLE
refactor(lists): remove unused importAsCopy (#43)

### DIFF
--- a/src/stores/lists.ts
+++ b/src/stores/lists.ts
@@ -1,6 +1,5 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
-import { v4 as uuidv4 } from 'uuid'
 import type List from '@/classes/List'
 import type Item from '@/classes/Item'
 import { getMeta } from '@/sync/storage'
@@ -102,18 +101,6 @@ export const useListsStore = defineStore('lists', () => {
     persist()
   }
 
-  function importAsCopy (incoming: List) {
-    const copy: List = {
-      id: uuidv4().substring(0, 8),
-      n: incoming.n,
-      i: incoming.i
-    }
-    sortItems(copy)
-    lists.value.push(copy)
-    persist()
-    return copy.id
-  }
-
   return {
     lists,
     getListFromId,
@@ -125,7 +112,6 @@ export const useListsStore = defineStore('lists', () => {
     softDeleteItem,
     replaceList,
     mergeList,
-    updateListId,
-    importAsCopy
+    updateListId
   }
 })

--- a/tests/unit/stores/lists.spec.js
+++ b/tests/unit/stores/lists.spec.js
@@ -150,25 +150,4 @@ describe('lists store', () => {
       expect(store.lists[0].i[0].d).toBe(1)
     })
   })
-
-  describe('importAsCopy', () => {
-    it('creates a new list with a fresh id', () => {
-      const store = useListsStore()
-      const incoming = { id: 'abc', n: 'Costco', i: [{ id: 'i1', n: 'Eggs', q: '1', c: 0, u: 1, d: 0 }] }
-      const newId = store.importAsCopy(incoming)
-      expect(newId).not.toBe('abc')
-      expect(store.lists).toHaveLength(1)
-      expect(store.lists[0].id).toBe(newId)
-      expect(store.lists[0].n).toBe('Costco')
-    })
-
-    it('does not overwrite an existing list with the same incoming id', () => {
-      const store = useListsStore()
-      store.createList({ id: 'abc', n: 'Original', i: [] })
-      store.importAsCopy({ id: 'abc', n: 'Imported', i: [] })
-      expect(store.lists).toHaveLength(2)
-      expect(store.lists[0].n).toBe('Original')
-      expect(store.lists[1].n).toBe('Imported')
-    })
-  })
 })


### PR DESCRIPTION
## Summary
- Drops `importAsCopy` from the lists store (no callers in `src/`).
- Removes its `describe` block and the now-unused `uuid` import.

Residue from the removed share-via-QR feature.

Closes #43

## Test plan
- [x] `npm run test:unit`
- [x] `npm run lint`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)