### PR TITLE
refactor(tests): migrate unit specs from .js to .ts (#53)

### DIFF
--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -31,8 +31,8 @@ describe('App.vue', () => {
   beforeEach(() => {
     localStorage.clear()
     window.location.hash = ''
-    HTMLDialogElement.prototype.showModal = vi.fn(function () { this.open = true })
-    HTMLDialogElement.prototype.close = vi.fn(function () {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) { this.open = true })
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
       this.open = false
       this.dispatchEvent(new Event('close'))
     })

--- a/tests/unit/AppJoin.spec.ts
+++ b/tests/unit/AppJoin.spec.ts
@@ -1,6 +1,6 @@
 import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia } from 'pinia'
-import { createRouter, createMemoryHistory } from 'vue-router'
+import { createRouter, createMemoryHistory, type Router } from 'vue-router'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import App from '@/App.vue'
 
@@ -23,7 +23,7 @@ const makeRouter = () => createRouter({
   ]
 })
 
-const mountApp = async (router) => {
+const mountApp = async (router: Router) => {
   await router.push('/')
   const wrapper = mount(App, {
     global: {
@@ -40,8 +40,8 @@ describe('App.vue — handleJoinFragment', () => {
     localStorage.clear()
     window.location.hash = ''
     vi.resetAllMocks()
-    HTMLDialogElement.prototype.showModal = vi.fn(function () { this.open = true })
-    HTMLDialogElement.prototype.close = vi.fn(function () {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) { this.open = true })
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
       this.open = false
       this.dispatchEvent(new Event('close'))
     })
@@ -55,7 +55,7 @@ describe('App.vue — handleJoinFragment', () => {
   })
 
   it('calls join and navigates to the list on a valid fragment', async () => {
-    sync.join.mockResolvedValue(true)
+    vi.mocked(sync.join).mockResolvedValue(true)
     window.location.hash = '#join=listid123.tokenxyz'
     const router = makeRouter()
     await mountApp(router)
@@ -65,7 +65,7 @@ describe('App.vue — handleJoinFragment', () => {
   })
 
   it('navigates without calling join when list is already synced', async () => {
-    sync.getMeta.mockReturnValue({ authToken: 'tok', role: 'owner', lastCursor: 1 })
+    vi.mocked(sync.getMeta).mockReturnValue({ authToken: 'tok', role: 'owner', lastCursor: 1 })
     window.location.hash = '#join=listid123.tokenxyz'
     const router = makeRouter()
     await mountApp(router)
@@ -74,7 +74,7 @@ describe('App.vue — handleJoinFragment', () => {
   })
 
   it('stays on Lists and does not navigate when join fails', async () => {
-    sync.join.mockResolvedValue(false)
+    vi.mocked(sync.join).mockResolvedValue(false)
     window.location.hash = '#join=listid123.tokenxyz'
     const router = makeRouter()
     await mountApp(router)

--- a/tests/unit/components/AppHeader.spec.ts
+++ b/tests/unit/components/AppHeader.spec.ts
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
 import AppHeader from '@/components/AppHeader.vue'
 
 describe('AppHeader.vue', () => {

--- a/tests/unit/components/ConfirmModal.spec.ts
+++ b/tests/unit/components/ConfirmModal.spec.ts
@@ -14,8 +14,8 @@ const mountModal = (props = {}) => mount(ConfirmModal, {
 
 describe('ConfirmModal', () => {
   beforeEach(() => {
-    HTMLDialogElement.prototype.showModal = vi.fn(function () { this.open = true })
-    HTMLDialogElement.prototype.close = vi.fn(function () {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) { this.open = true })
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
       this.open = false
       this.dispatchEvent(new Event('close'))
     })
@@ -44,21 +44,21 @@ describe('ConfirmModal', () => {
 
   it('applies primary variant by default', () => {
     const wrapper = mountModal({ confirmLabel: 'Confirm' })
-    const confirmBtn = wrapper.findAll('button').find(b => b.text() === 'Confirm')
+    const confirmBtn = wrapper.findAll('button').find(b => b.text() === 'Confirm')!
     expect(confirmBtn.classes()).toContain('confirm-modal__button--primary')
     expect(confirmBtn.classes()).not.toContain('confirm-modal__button--destructive')
   })
 
   it('applies destructive variant class when variant=destructive', () => {
     const wrapper = mountModal({ variant: 'destructive', confirmLabel: 'Delete' })
-    const confirmBtn = wrapper.findAll('button').find(b => b.text() === 'Delete')
+    const confirmBtn = wrapper.findAll('button').find(b => b.text() === 'Delete')!
     expect(confirmBtn.classes()).toContain('confirm-modal__button--destructive')
     expect(confirmBtn.classes()).not.toContain('confirm-modal__button--primary')
   })
 
   it('emits confirm + update:open=false when Confirm is clicked', async () => {
     const wrapper = mountModal({ open: true })
-    await wrapper.findAll('button').find(b => b.text() === 'Confirm').trigger('click')
+    await wrapper.findAll('button').find(b => b.text() === 'Confirm')!.trigger('click')
     expect(wrapper.emitted('confirm')).toBeTruthy()
     expect(wrapper.emitted('update:open')).toEqual([[false]])
     expect(wrapper.emitted('cancel')).toBeFalsy()
@@ -66,7 +66,7 @@ describe('ConfirmModal', () => {
 
   it('emits cancel + update:open=false when Cancel is clicked', async () => {
     const wrapper = mountModal({ open: true })
-    await wrapper.findAll('button').find(b => b.text() === 'Cancel').trigger('click')
+    await wrapper.findAll('button').find(b => b.text() === 'Cancel')!.trigger('click')
     expect(wrapper.emitted('cancel')).toBeTruthy()
     expect(wrapper.emitted('update:open')).toEqual([[false]])
     expect(wrapper.emitted('confirm')).toBeFalsy()

--- a/tests/unit/components/ShareSheet.spec.ts
+++ b/tests/unit/components/ShareSheet.spec.ts
@@ -16,12 +16,12 @@ vi.mock('qrcode', () => ({
 }))
 
 vi.mock('@/sync', () => ({
-  provision: (...args) => provisionMock(...args),
-  isSynced: (...args) => isSyncedMock(...args),
-  getMeta: (...args) => getMetaMock(...args),
-  enableSharing: (...args) => enableSharingMock(...args),
-  disableSharing: (...args) => disableSharingMock(...args),
-  deleteList: (...args) => deleteListMock(...args)
+  provision: (...args: unknown[]) => provisionMock(...args),
+  isSynced: (...args: unknown[]) => isSyncedMock(...args),
+  getMeta: (...args: unknown[]) => getMetaMock(...args),
+  enableSharing: (...args: unknown[]) => enableSharingMock(...args),
+  disableSharing: (...args: unknown[]) => disableSharingMock(...args),
+  deleteList: (...args: unknown[]) => deleteListMock(...args)
 }))
 
 const list = { id: 'l1', n: 'Costco', i: [{ id: 'i1', n: 'Eggs', q: '1', c: 0, u: 1, d: 0 }] }
@@ -44,8 +44,8 @@ describe('ShareSheet', () => {
     disableSharingMock.mockResolvedValue(true)
     deleteListMock.mockResolvedValue(true)
     getMetaMock.mockReturnValue(null)
-    HTMLDialogElement.prototype.showModal = vi.fn(function () { this.open = true })
-    HTMLDialogElement.prototype.close = vi.fn(function () {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) { this.open = true })
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
       this.open = false
       this.dispatchEvent(new Event('close'))
     })
@@ -108,14 +108,14 @@ describe('ShareSheet', () => {
   it('copies URL to clipboard when Copy is clicked', async () => {
     const wrapper = mountSheet({ open: true })
     await flushPromises()
-    await wrapper.findAll('button').find(b => b.text().includes('Copy link')).trigger('click')
+    await wrapper.findAll('button').find(b => b.text().includes('Copy link'))!.trigger('click')
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(SHARE_URL)
   })
 
   it('invokes navigator.share when Share link is clicked', async () => {
     const wrapper = mountSheet({ open: true })
     await flushPromises()
-    await wrapper.findAll('button').find(b => b.text().includes('Share link')).trigger('click')
+    await wrapper.findAll('button').find(b => b.text().includes('Share link'))!.trigger('click')
     expect(navigator.share).toHaveBeenCalledWith(expect.objectContaining({ url: SHARE_URL }))
   })
 
@@ -125,7 +125,7 @@ describe('ShareSheet', () => {
     const wrapper = mountSheet({ open: true })
     await flushPromises()
 
-    await wrapper.findAll('button').find(b => b.text().includes('Enable sharing')).trigger('click')
+    await wrapper.findAll('button').find(b => b.text().includes('Enable sharing'))!.trigger('click')
     await flushPromises()
 
     expect(enableSharingMock).toHaveBeenCalledWith('l1')
@@ -139,7 +139,7 @@ describe('ShareSheet', () => {
     const wrapper = mountSheet({ open: true })
     await flushPromises()
 
-    await wrapper.findAll('button').find(b => b.text().includes('Stop sharing')).trigger('click')
+    await wrapper.findAll('button').find(b => b.text().includes('Stop sharing'))!.trigger('click')
     await flushPromises()
 
     expect(disableSharingMock).toHaveBeenCalledWith('l1')
@@ -190,7 +190,7 @@ describe('ShareSheet', () => {
     })
     const wrapper = mountSheet({ open: true })
     await flushPromises()
-    await wrapper.findAll('button').find(b => b.text().includes('Copy link')).trigger('click')
+    await wrapper.findAll('button').find(b => b.text().includes('Copy link'))!.trigger('click')
     await flushPromises()
     expect(true).toBe(true)
   })
@@ -202,7 +202,7 @@ describe('ShareSheet', () => {
     })
     const wrapper = mountSheet({ open: true })
     await flushPromises()
-    await wrapper.findAll('button').find(b => b.text().includes('Share link')).trigger('click')
+    await wrapper.findAll('button').find(b => b.text().includes('Share link'))!.trigger('click')
     await flushPromises()
     expect(true).toBe(true)
   })

--- a/tests/unit/stores/lists.spec.ts
+++ b/tests/unit/stores/lists.spec.ts
@@ -1,4 +1,5 @@
 import { setActivePinia, createPinia } from 'pinia'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { useListsStore } from '@/stores/lists'
 import List from '@/classes/List'
 import Item from '@/classes/Item'
@@ -33,7 +34,7 @@ describe('lists store', () => {
     store.createList(new List('Groceries', []))
     expect(store.lists).toHaveLength(1)
     expect(store.lists[0].n).toBe('Groceries')
-    expect(JSON.parse(localStorage.getItem('lists'))[0].n).toBe('Groceries')
+    expect(JSON.parse(localStorage.getItem('lists') ?? '[]')[0].n).toBe('Groceries')
   })
 
   it('deleteList removes by id and persists', () => {
@@ -42,7 +43,7 @@ describe('lists store', () => {
     store.createList(list)
     store.deleteList(list.id)
     expect(store.lists).toHaveLength(0)
-    expect(JSON.parse(localStorage.getItem('lists'))).toHaveLength(0)
+    expect(JSON.parse(localStorage.getItem('lists') ?? '[]')).toHaveLength(0)
   })
 
   it('addItem sorts items alphabetically by name', () => {
@@ -69,7 +70,7 @@ describe('lists store', () => {
     const store = useListsStore()
     const list = new List('A', [])
     store.createList(list)
-    expect(store.getListFromId(list.id).n).toBe('A')
+    expect(store.getListFromId(list.id)!.n).toBe('A')
   })
 
   it('getListFromId returns undefined for unknown id', () => {

--- a/tests/unit/views/List.spec.ts
+++ b/tests/unit/views/List.spec.ts
@@ -2,13 +2,14 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import { nextTick } from 'vue'
 import { createRouter, createMemoryHistory } from 'vue-router'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { useListsStore } from '@/stores/lists'
 import ListV from '@/views/List.vue'
 
 const listId = 'test01'
 
 const makeItem = (overrides = {}) => ({
-  id: 'item1', n: 'Apples', q: 2, c: 0, d: 0, u: 0, ...overrides
+  id: 'item1', n: 'Apples', q: '2', c: 0, d: 0, u: 0, ...overrides
 })
 
 const routes = [
@@ -52,11 +53,12 @@ const mountListWithSheet = async () => {
   const router = createRouter({ history: createMemoryHistory(), routes })
   await router.push({ name: 'List', params: { id: 'local01' } })
 
-  let sheetEmit = null
+  type Emit = (event: string, ...args: unknown[]) => void
+  let sheetEmit: Emit | null = null
   const ShareSheetStub = {
     props: ['open', 'list'],
     emits: ['update:open', 'provisioned', 'deleted'],
-    setup (_, { emit }) { sheetEmit = emit; return () => null }
+    setup (_: unknown, { emit }: { emit: Emit }) { sheetEmit = emit; return () => null }
   }
 
   const wrapper = mount(ListV, {
@@ -83,8 +85,8 @@ describe('List.vue', () => {
 
   it('renders item name and quantity', async () => {
     const { wrapper } = await mountList()
-    expect(wrapper.find('.item__name').element.value).toBe('Apples')
-    expect(wrapper.find('.item__quantity__input').element.value).toBe('2')
+    expect((wrapper.find('.item__name').element as HTMLInputElement).value).toBe('Apples')
+    expect((wrapper.find('.item__quantity__input').element as HTMLInputElement).value).toBe('2')
   })
 
   it('shows empty-state when there are no active items', async () => {
@@ -154,8 +156,8 @@ describe('List.vue', () => {
       await nextTick()
 
       // Simulate ShareSheet emitting provisioned then closing (as onClose does)
-      sheetEmit()('provisioned', 'SERVER01')
-      sheetEmit()('update:open', false)
+      sheetEmit()!('provisioned', 'SERVER01')
+      sheetEmit()!('update:open', false)
       await flushPromises()
 
       expect(router.currentRoute.value.name).toBe('List')

--- a/tests/unit/views/Lists.spec.ts
+++ b/tests/unit/views/Lists.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createTestingPinia } from '@pinia/testing'
 import { useListsStore } from '@/stores/lists'
 import Lists from '@/views/Lists.vue'
+import type List from '@/classes/List'
 
 import * as sync from '@/sync'
 
@@ -17,7 +18,7 @@ const stubs = {
   FontAwesomeIcon: { template: '<span />' }
 }
 
-const mountLists = (lists) => mount(Lists, {
+const mountLists = (lists: List[]) => mount(Lists, {
   global: {
     plugins: [createTestingPinia({ initialState: { lists: { lists } } })],
     stubs
@@ -26,8 +27,8 @@ const mountLists = (lists) => mount(Lists, {
 
 describe('Lists.vue', () => {
   beforeEach(() => {
-    HTMLDialogElement.prototype.showModal = vi.fn(function () { this.open = true })
-    HTMLDialogElement.prototype.close = vi.fn(function () {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) { this.open = true })
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
       this.open = false
       this.dispatchEvent(new Event('close'))
     })
@@ -66,7 +67,7 @@ describe('Lists.vue', () => {
     const wrapper = mountLists([{ id: 'a1', n: 'Fruit', i: [] }])
     const store = useListsStore()
     await wrapper.find('.list__icon--delete').trigger('click')
-    await wrapper.findAll('button').find(b => b.text() === 'Delete').trigger('click')
+    await wrapper.findAll('button').find(b => b.text() === 'Delete')!.trigger('click')
     await wrapper.vm.$nextTick()
     expect(store.deleteList).toHaveBeenCalledWith('a1')
     expect(wrapper.find('.confirm-modal').exists()).toBe(false)
@@ -78,7 +79,7 @@ describe('Lists.vue', () => {
     const wrapper = mountLists([{ id: 'srv1', n: 'Shared', i: [] }])
     const store = useListsStore()
     await wrapper.find('.list__icon--delete').trigger('click')
-    await wrapper.findAll('button').find(b => b.text() === 'Delete').trigger('click')
+    await wrapper.findAll('button').find(b => b.text() === 'Delete')!.trigger('click')
     await wrapper.vm.$nextTick()
     expect(sync.deleteList).toHaveBeenCalledWith('srv1')
     expect(store.deleteList).not.toHaveBeenCalled()
@@ -90,7 +91,7 @@ describe('Lists.vue', () => {
     const wrapper = mountLists([{ id: 'srv2', n: 'Joined', i: [] }])
     const store = useListsStore()
     await wrapper.find('.list__icon--delete').trigger('click')
-    await wrapper.findAll('button').find(b => b.text() === 'Delete').trigger('click')
+    await wrapper.findAll('button').find(b => b.text() === 'Delete')!.trigger('click')
     await wrapper.vm.$nextTick()
     expect(sync.leaveList).toHaveBeenCalledWith('srv2')
     expect(store.deleteList).not.toHaveBeenCalled()
@@ -101,7 +102,7 @@ describe('Lists.vue', () => {
     const wrapper = mountLists([{ id: 'a1', n: 'Fruit', i: [] }])
     const store = useListsStore()
     await wrapper.find('.list__icon--delete').trigger('click')
-    await wrapper.findAll('button').find(b => b.text() === 'Cancel').trigger('click')
+    await wrapper.findAll('button').find(b => b.text() === 'Cancel')!.trigger('click')
     expect(store.deleteList).not.toHaveBeenCalled()
     expect(wrapper.find('.confirm-modal').exists()).toBe(false)
   })

--- a/tests/unit/views/New.spec.ts
+++ b/tests/unit/views/New.spec.ts
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
 import { createRouter, createMemoryHistory } from 'vue-router'
+import { describe, it, expect, vi } from 'vitest'
 import { useListsStore } from '@/stores/lists'
 import New from '@/views/New.vue'
 


### PR DESCRIPTION
## Summary
- Renames the 9 remaining `.js` unit specs to `.ts` so all tests share the same lint and type rules as the existing `.ts` specs.
- Mechanical per-file fixups for strict mode:
  - Explicit `vitest` imports where missing.
  - `vi.fn(function (this: HTMLDialogElement) {...})` for the dialog prototype shims.
  - `vi.mocked(sync.fn).mockResolvedValue(...)` instead of `sync.fn.mockResolvedValue(...)`.
  - `(wrapper.find(...).element as HTMLInputElement).value` for input reads.
  - `findAll().find(...)!` non-null assertions.
  - Typed `sheetEmit`, `setup` args, and `(...args)` rest params in mock factories.

No production code changes. No config changes — `vite.config.js` already includes both `.js` and `.ts` test patterns; `tsconfig.json` already covers `tests/**/*` with strict mode.

Closes #53

## Test plan
- [x] `npm run test:unit` (174 passing)
- [x] `npm run lint`
- [x] `npm run build` (vue-tsc strict — clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)