### PR TITLE
fix(a11y): single live region for SR announcements (#56)

### DIFF
--- a/src/components/ToastContainer.vue
+++ b/src/components/ToastContainer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="toast-container" aria-live="assertive" aria-atomic="false">
+  <div class="toast-container">
     <div v-for="toast in toastStore.toasts"
          :key="toast.id"
          class="toast"

--- a/src/stores/toast.ts
+++ b/src/stores/toast.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
+import { useLiveRegion } from '@/composables/useLiveRegion'
 
 interface Toast {
   id: number
@@ -14,6 +15,7 @@ export const useToastStore = defineStore('toast', () => {
   function add (message: string, type: Toast['type'] = 'info'): void {
     const id = nextId++
     toasts.value.push({ id, message, type })
+    useLiveRegion().announce(message)
     setTimeout(() => dismiss(id), 5000)
   }
 


### PR DESCRIPTION
## Summary
- Drop `aria-live` from `ToastContainer` so the container is visual-only.
- Route `toast.add` through `useLiveRegion().announce()` so the App.vue polite region is the sole SR channel.

Closes #56.

## Test plan
- [x] `npm run test:unit` — 174 pass
- [x] `npm run lint`
- [x] `npm run type-check`
- [ ] Manual: trigger a toast and an `announce()` concurrently with a screen reader; confirm only one announcement plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)