### PR TITLE
fix(a11y): drop misleading aria-pressed on theme toggle

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -14,7 +14,6 @@
       <button
         class="header__theme-toggle"
         :aria-label="`Switch to ${nextMode} mode`"
-        :aria-pressed="false"
         @click="cycleMode"
       >
         <font-awesome-icon :icon="modeIcon"/>

--- a/tests/unit/components/AppHeader.spec.ts
+++ b/tests/unit/components/AppHeader.spec.ts
@@ -19,4 +19,10 @@ describe('AppHeader.vue', () => {
   it('renders the New List link', () => {
     expect(wrapper.text()).toContain('New List')
   })
+
+  it('exposes the theme toggle as an unpressed-agnostic button', () => {
+    const toggle = wrapper.get('button.header__theme-toggle')
+    expect(toggle.attributes('aria-label')).toMatch(/^Switch to (light|dark|system) mode$/)
+    expect(toggle.attributes('aria-pressed')).toBeUndefined()
+  })
 })


### PR DESCRIPTION
## Summary
- The header theme toggle cycles `light → dark → system`, but `aria-pressed` is defined for binary toggle buttons. Hard-coding it to `false` reported inaccurate state to assistive tech.
- Removed the attribute; the existing dynamic `aria-label` (`Switch to {nextMode} mode`) already communicates current + next state, so no replacement is needed.
- Added a unit assertion so the regression can't sneak back in.

Closes #55

## Test plan
- [x] `npm run test:unit` (175 passed)
- [x] `npm run lint`
- [x] `npm run type-check`
- [ ] Smoke-test in browser: cycle through light/dark/system with VoiceOver/NVDA and confirm announcements describe the next state, not a pressed/unpressed state

🤖 Generated with [Claude Code](https://claude.com/claude-code)