### PR TITLE
chore: bump wrangler compatibility_date to 2026-05-01 (#50)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ pnpm-debug.log*
 /playwright-report
 /test-results
 /.wrangler
+worker-configuration.d.ts

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,5 @@
 name = "grocerieslist-app"
-compatibility_date = "2024-12-01"
+compatibility_date = "2026-05-01"
 pages_build_output_dir = "dist"
 
 [[d1_databases]]


### PR DESCRIPTION
## Summary
- Bumps `wrangler.toml` `compatibility_date` from `2024-12-01` to `2026-05-01` to pick up ~17 months of Workers runtime improvements and bug fixes.
- Pages Functions only use stable runtime APIs (`Response.json`, `fetch`, `crypto.subtle`, `crypto.getRandomValues`, D1) — no legacy-behavior dependencies.

Closes #50

## Test plan
- [x] `npx wrangler types` parses config cleanly
- [x] `npm run build` (vue-tsc + vite) succeeds
- [ ] Cloudflare Pages preview deploy green

🤖 Generated with [Claude Code](https://claude.com/claude-code)