### PR TITLE
perf: move tombstone GC to nightly GH Actions cron (#39)

### DIFF
--- a/.github/workflows/gc-tombstones.yml
+++ b/.github/workflows/gc-tombstones.yml
@@ -1,0 +1,32 @@
+name: gc-tombstones
+
+# Nightly sweep of soft-deleted items past their 90-day TTL.
+# Moved out of the upsert write path — see GitHub Issue #39.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # 03:00 UTC daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete tombstoned items older than 90 days
+        env:
+          ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
+          API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          cutoff=$(( $(date +%s%3N) - 7776000000 ))  # now - 90 days, in ms
+          response=$(curl -fsS -X POST \
+            "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/d1/database/${DATABASE_ID}/query" \
+            -H "Authorization: Bearer ${API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"sql\":\"DELETE FROM items WHERE d = 1 AND u < ?\",\"params\":[\"${cutoff}\"]}")
+          echo "$response"
+          echo "$response" | grep -q '"success":true'

--- a/functions/api/_shared/handlers.ts
+++ b/functions/api/_shared/handlers.ts
@@ -4,8 +4,6 @@ import { authenticate } from './auth'
 import { hashToken } from '../../../shared/crypto'
 import { LIMITS, readJsonBody, validateItem } from './validate'
 
-const TOMBSTONE_TTL_MS = 90 * 24 * 60 * 60 * 1000
-
 export async function handleUpsertItem (
   db: D1Database,
   request: Request,
@@ -37,8 +35,7 @@ export async function handleUpsertItem (
        ON CONFLICT(list_id, id) DO UPDATE
        SET n=excluded.n, q=excluded.q, c=excluded.c, u=excluded.u, d=excluded.d`
     ).bind(listId, itemId, incoming.n, incoming.q, incoming.c, incoming.u, incoming.d),
-    db.prepare('UPDATE lists SET version = version + 1 WHERE id = ?').bind(listId),
-    db.prepare('DELETE FROM items WHERE list_id = ? AND d = 1 AND u < ?').bind(listId, Date.now() - TOMBSTONE_TTL_MS)
+    db.prepare('UPDATE lists SET version = version + 1 WHERE id = ?').bind(listId)
   ])
 
   return Response.json({ item: incoming })

--- a/schema.sql
+++ b/schema.sql
@@ -29,3 +29,4 @@ CREATE TABLE IF NOT EXISTS items (
 );
 
 CREATE INDEX IF NOT EXISTS items_by_version ON items(list_id, u);
+CREATE INDEX IF NOT EXISTS items_by_tombstone ON items(d, u);

--- a/tests/integration/api/lists.spec.ts
+++ b/tests/integration/api/lists.spec.ts
@@ -601,9 +601,10 @@ describe('DELETE /api/lists/:id', () => {
     expect(res.status).toBe(401)
   })
 
-  it('tombstone GC — removes d=1 items older than 30 days on write', async () => {
+  it('tombstone sweep — removes d=1 items older than 90 days, keeps newer tombstones and live items', async () => {
     const { id, authToken } = await setup()
-    const ninetyOneDaysAgo = Date.now() - 91 * 24 * 60 * 60 * 1000
+    const now = Date.now()
+    const ttlMs = 90 * 24 * 60 * 60 * 1000
 
     const upsertReq = (itemId: string, item: object) => new Request(`http://localhost/api/lists/${id}/items/${itemId}`, {
       method: 'POST',
@@ -611,18 +612,20 @@ describe('DELETE /api/lists/:id', () => {
       body: JSON.stringify(item)
     })
 
-    // Insert old tombstone
-    await handleUpsertItem(db, upsertReq('tombstone1', { n: 'Old Item', q: '1', c: 0, u: ninetyOneDaysAgo, d: 1 }), id, 'tombstone1')
-    // Write a new item to trigger GC
-    await handleUpsertItem(db, upsertReq('item0002', { n: 'New Item', q: '2', c: 0, u: Date.now(), d: 0 }), id, 'item0002')
+    await handleUpsertItem(db, upsertReq('old-tomb', { n: 'Old', q: '1', c: 0, u: now - 91 * 24 * 60 * 60 * 1000, d: 1 }), id, 'old-tomb')
+    await handleUpsertItem(db, upsertReq('new-tomb', { n: 'Recent', q: '1', c: 0, u: now - 24 * 60 * 60 * 1000, d: 1 }), id, 'new-tomb')
+    await handleUpsertItem(db, upsertReq('live', { n: 'Live', q: '1', c: 0, u: now, d: 0 }), id, 'live')
 
-    // Poll — old tombstone should be gone
+    // Execute the same DELETE the nightly GH Actions workflow runs.
+    await db.prepare('DELETE FROM items WHERE d = 1 AND u < ?').bind(now - ttlMs).run()
+
     const pollReq = new Request(`http://localhost/api/lists/${id}?since=0`, {
       headers: { Authorization: `Bearer ${authToken}` }
     })
     const body = await handlePoll(db, pollReq, id).then(r => r.json() as Promise<{ items: Array<{ id: string }> }>)
     const ids = body.items.map(i => i.id)
-    expect(ids).not.toContain('tombstone1')
-    expect(ids).toContain('item0002')
+    expect(ids).not.toContain('old-tomb')
+    expect(ids).toContain('new-tomb')
+    expect(ids).toContain('live')
   })
 })


### PR DESCRIPTION
## Summary
- Drop the per-write `DELETE FROM items WHERE list_id = ? AND d = 1 AND u < ?` from `handleUpsertItem` — it ran on every item write, adding a third statement to every batch.
- Replace with a nightly GitHub Actions workflow that hits the D1 REST API to sweep soft-deleted items past their 90-day TTL across all lists.
- Add `items_by_tombstone(d, u)` index so the sweep scales.

Closes #39.

## Why GH Actions instead of a Cloudflare Worker?
Pages Functions don't support cron triggers (Workers do). A sidecar Worker would work but adds a second deploy target. For a 90-day TTL sweep, GH Actions cron is the leaner fit:
- No new deploy target, just a YAML file.
- GH cron can be delayed under load — fine here, the TTL is 90 days.
- Public repo → unlimited Actions minutes. D1 free tier covers it easily.

## Required setup before merge
Three repository secrets:
- `CLOUDFLARE_API_TOKEN` — scope to **D1:Edit** on your account only.
- `CLOUDFLARE_ACCOUNT_ID`
- `D1_DATABASE_ID` — value is `75b68a5a-a7d1-43ed-9fea-a57f2537916d` per `wrangler.toml`.

Also apply the new index to prod D1 once:
```
npx wrangler d1 execute grocerieslist-sync --remote --command "CREATE INDEX IF NOT EXISTS items_by_tombstone ON items(d, u);"
```

## Test plan
- [x] `npm run test:integration` — rewrote the existing tombstone test to exercise the new sweep SQL directly against miniflare D1. Verifies old tombstones go, recent ones stay, live items stay.
- [x] `npm run test:unit`
- [x] `npm run type-check`
- [x] `npm run lint`
- [ ] After merge: add the 3 secrets, run the wrangler command, then trigger the workflow once via `workflow_dispatch` to confirm a clean run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)