### PR TITLE
fix: add standardized mobile-web-app-capable meta (#78)

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta name="theme-color" content="#111827">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <meta name="msapplication-TileColor" content="#111827">
     <link rel="icon" href="/icon.svg">


### PR DESCRIPTION
## Summary
- Add `<meta name="mobile-web-app-capable" content="yes">` alongside the `apple-` variant in `index.html`
- Silences the Chrome deprecation warning logged on page load (issue #78)
- Both tags coexist: iOS Safari still requires the `apple-` prefix; the unprefixed name is the standardized equivalent for Chrome on Android

Closes #78

## Test plan
- [x] Load app in Chrome — no `apple-mobile-web-app-capable is deprecated` warning in console
- [ ] Load on iOS Safari — PWA install / standalone behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)