### PR TITLE
fix: use crypto.randomUUID for list/item IDs (#42)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "tailwindcss": "^4.2.4",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.2",
-        "uuid": "^14.0.0",
         "vite": "^8.0.10",
         "vite-plugin-pwa": "^1.3.0",
         "vitest": "^4.1.5",
@@ -13357,20 +13356,6 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
     "node_modules/vite": {
       "version": "8.0.10",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
@@ -22466,12 +22451,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
-    "uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true
     },
     "vite": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "tailwindcss": "^4.2.4",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.2",
-    "uuid": "^14.0.0",
     "vite": "^8.0.10",
     "vite-plugin-pwa": "^1.3.0",
     "vitest": "^4.1.5",

--- a/src/classes/Item.ts
+++ b/src/classes/Item.ts
@@ -1,5 +1,3 @@
-import { v4 as uuidv4 } from 'uuid'
-
 export default class Item {
   id: string
   n: string
@@ -9,7 +7,7 @@ export default class Item {
   d: number
 
   constructor (name: string, quantity: string) {
-    this.id = uuidv4().substring(0, 8)
+    this.id = crypto.randomUUID()
     this.n = name
     this.q = quantity
     this.c = 0

--- a/src/classes/List.ts
+++ b/src/classes/List.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from 'uuid'
 import type Item from './Item'
 
 export default class List {
@@ -7,7 +6,7 @@ export default class List {
   i: Item[]
 
   constructor (name: string, items: Item[]) {
-    this.id = uuidv4().substring(0, 8)
+    this.id = crypto.randomUUID()
     this.n = name
     this.i = items
   }

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -20,7 +20,7 @@ test('smoke: critical path', async ({ page }) => {
   // Create list named "Test"
   await page.getByPlaceholder('List Name').fill('Test')
   await page.getByRole('button', { name: 'Create' }).click()
-  await expect(page).toHaveURL(/\/[a-f0-9]{8}$/)
+  await expect(page).toHaveURL(/\/[a-f0-9-]{36}$/)
   await expect(page.getByRole('heading', { level: 1 })).toHaveText('Test')
 
   // Add item "Apples" qty 3
@@ -54,7 +54,7 @@ test('a11y: List route — initial state', async ({ page }) => {
   await page.goto('/new')
   await page.getByPlaceholder('List Name').fill('A11y Test')
   await page.getByRole('button', { name: 'Create' }).click()
-  await expect(page).toHaveURL(/\/[a-f0-9]{8}$/)
+  await expect(page).toHaveURL(/\/[a-f0-9-]{36}$/)
   // Wait for route transition to complete before axe scans
   await expect(page.getByRole('heading', { level: 1 })).toHaveText('A11y Test')
   await checkA11y(page)
@@ -85,7 +85,7 @@ test('a11y: Lists route — after creating a list', async ({ page }) => {
   await page.goto('/new')
   await page.getByPlaceholder('List Name').fill('A11y Test')
   await page.getByRole('button', { name: 'Create' }).click()
-  await expect(page).toHaveURL(/\/[a-f0-9]{8}$/)
+  await expect(page).toHaveURL(/\/[a-f0-9-]{36}$/)
   await page.getByRole('link', { name: 'My Lists' }).click()
   await expect(page).toHaveURL('/')
   await expect(page.getByRole('link', { name: /A11y Test/ })).toBeVisible()


### PR DESCRIPTION
## Summary
- Replace truncated `uuidv4().substring(0, 8)` (~32 bits) with `crypto.randomUUID()` (122 bits) in `Item` and `List` constructors.
- Drop the `uuid` runtime dep — only 2 call sites, both removed.

## Why
Per #42, 8-char IDs are collision-real:
- **List IDs** are replaced by a server-minted ULID on `provision()`, so client list-ID collisions only matter for lists that are never shared. Still worth hardening for parity.
- **Item IDs** stay client-generated forever and are used as part of the composite PK `(list_id, id)`. Per-list collisions in a heavily-edited list aren't impossible at ~32 bits.

`crypto.randomUUID()` is available in all evergreen browsers, Cloudflare Workers, and Node 18+ (used by jsdom in unit tests). No polyfill needed.

## Migration
Existing 8-char IDs in users' `localStorage` are left as-is. The server schema (`itemIdMax: 64`) accepts any string id, and lookups are by exact match — mixed-length coexistence is fine. New lists/items use full UUIDs going forward.

## Test plan
- [x] `npm run lint` — clean (only pre-existing `worker-configuration.d.ts` warnings)
- [x] `npm run type-check` — clean
- [x] `npm run test:unit` — 175/175 passing
- [x] `npm run test:integration` — 40/40 passing

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)