### PR TITLE
chore(ci): gate functions/ coverage in integration tests (#54)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run test:coverage
-      - run: npm run test:integration
+      - run: npm run test:integration:coverage
       - run: npm run build
       - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test:integration": "vitest run --config tests/integration/vitest.integration.config.ts",
+    "test:integration:coverage": "vitest run --config tests/integration/vitest.integration.config.ts --coverage",
     "test:e2e": "playwright test",
     "dev:pages": "wrangler pages dev dist"
   },

--- a/tests/integration/vitest.integration.config.ts
+++ b/tests/integration/vitest.integration.config.ts
@@ -6,6 +6,25 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     testTimeout: 30_000,
-    setupFiles: []
+    setupFiles: [],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['functions/**'],
+      exclude: [
+        'functions/**/*.d.ts',
+        'functions/tsconfig.json',
+        // Route entry wrappers: one-line PagesFunction adapters around
+        // _shared/handlers. Require a full Pages runtime to exercise;
+        // their handler bodies are covered via direct invocation in tests.
+        'functions/api/lists/**'
+      ],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 75,
+        statements: 80
+      }
+    }
   }
 })


### PR DESCRIPTION
## Summary
- Adds a v8 coverage block to `tests/integration/vitest.integration.config.ts` covering `functions/**`, mirroring the unit-test thresholds (80/80/75/80)
- Excludes route entry wrappers under `functions/api/lists/**` — one-line `PagesFunction` adapters around `_shared/handlers` that are exercised directly via the integration tests
- New `test:integration:coverage` npm script; CI switches to it so the threshold is enforced

Current coverage on the gated surface:
- Statements: 91.77%
- Branches: 83.48%
- Functions: 92.85%
- Lines: 94.02%

Closes #54

## Test plan
- [x] `npm run test:integration:coverage` — 40/40 passing, all metrics above threshold
- [x] `npm run lint` — clean
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)