### PR TITLE
fix(list): focus next item via Vue refs after delete (#58)

### DIFF
--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -58,6 +58,7 @@
             <input type="text"
                    :id="`item-name-${item.id}`"
                    :value="item.n"
+                   :ref="setItemNameRef(item.id)"
                    class="item__name"
                    @change="modifyItemName($event, item.id)"/>
             <button @click="deleteItem(item.id)"
@@ -92,6 +93,7 @@
             <input type="text"
                    :id="`item-name-${item.id}`"
                    :value="item.n"
+                   :ref="setItemNameRef(item.id)"
                    class="item__name"
                    @change="modifyItemName($event, item.id)"/>
             <button @click="deleteItem(item.id)"
@@ -133,6 +135,11 @@ const list = computed(() => listsStore.getListFromId(listId.value))
 const name = ref<string | null>(null)
 const quantity = ref<number>(1)
 const itemName = ref<HTMLInputElement | null>(null)
+const itemNameRefs: Record<string, HTMLInputElement | null> = {}
+const setItemNameRef = (id: string) => (el: unknown) => {
+  if (el) itemNameRefs[id] = el as HTMLInputElement
+  else delete itemNameRefs[id]
+}
 const shareOpen = ref(false)
 const shareList = shallowRef<List | null>(null)
 const provisioning = ref(false)
@@ -189,15 +196,23 @@ async function deleteItem (id: string): Promise<void> {
   const item = list.value!.i.find(i => i.id === id)
   if (!item) return
   const deletedName = item.n
+
+  // Capture render-order snapshot BEFORE mutating so we can pick the
+  // deleted item's neighbor deterministically.
+  const active = list.value!.i.filter(i => !i.d)
+  const pending = active.filter(i => !i.c)
+  const checked = active.filter(i => i.c === 1)
+  const renderOrder = [...pending, ...checked]
+  const idx = renderOrder.findIndex(i => i.id === id)
+  const neighbor = renderOrder[idx + 1] ?? renderOrder[idx - 1]
+
   listsStore.softDeleteItem(listId.value, id)
   announce(`${deletedName} removed`)
   await nextTick()
-  const nextInput = document.querySelector<HTMLInputElement>('.item__name')
-  if (nextInput) {
-    nextInput.focus()
-  } else {
-    itemName.value?.focus()
-  }
+
+  const target = neighbor ? itemNameRefs[neighbor.id] : null
+  if (target) target.focus()
+  else itemName.value?.focus()
 }
 
 function toggleItemCheckedStatus (id: string): void {

--- a/tests/unit/views/List.spec.ts
+++ b/tests/unit/views/List.spec.ts
@@ -17,7 +17,7 @@ const routes = [
   { path: '/lists', name: 'Lists', component: { template: '<div/>' } }
 ]
 
-const mountList = async (items = [makeItem()]) => {
+const mountList = async (items = [makeItem()], opts: { attach?: boolean } = {}) => {
   const pinia = createPinia()
 
   const seeder = {
@@ -31,6 +31,7 @@ const mountList = async (items = [makeItem()]) => {
   await router.push({ name: 'List', params: { id: listId } })
 
   const wrapper = mount(ListV, {
+    ...(opts.attach ? { attachTo: document.body } : {}),
     global: {
       plugins: [pinia, seeder, router],
       stubs: { FontAwesomeIcon: { template: '<span />' } }
@@ -134,6 +135,40 @@ describe('List.vue', () => {
   it('shows the all-checked banner when every active item is checked', async () => {
     const { wrapper } = await mountList([makeItem({ c: 1 })])
     expect(wrapper.text()).toContain('checked off all your items')
+  })
+
+  describe('focus management after delete', () => {
+    const itemsForFocus = () => [
+      makeItem({ id: 'i1', n: 'Apples' }),
+      makeItem({ id: 'i2', n: 'Bread' }),
+      makeItem({ id: 'i3', n: 'Cheese' })
+    ]
+
+    it('focuses the next item after deleting a middle item', async () => {
+      const { wrapper } = await mountList(itemsForFocus(), { attach: true })
+      const deleteButtons = wrapper.findAll('.item__icon--delete')
+      await deleteButtons[1].trigger('click') // delete Bread
+      await flushPromises()
+      expect((document.activeElement as HTMLInputElement).id).toBe('item-name-i3')
+      wrapper.unmount()
+    })
+
+    it('focuses the previous item after deleting the last item', async () => {
+      const { wrapper } = await mountList(itemsForFocus(), { attach: true })
+      const deleteButtons = wrapper.findAll('.item__icon--delete')
+      await deleteButtons[2].trigger('click') // delete Cheese
+      await flushPromises()
+      expect((document.activeElement as HTMLInputElement).id).toBe('item-name-i2')
+      wrapper.unmount()
+    })
+
+    it('focuses the add-item input after deleting the only remaining item', async () => {
+      const { wrapper } = await mountList([makeItem({ id: 'only', n: 'Solo' })], { attach: true })
+      await wrapper.find('.item__icon--delete').trigger('click')
+      await flushPromises()
+      expect((document.activeElement as HTMLInputElement).id).toBe('name')
+      wrapper.unmount()
+    })
   })
 
   describe('navigation guard', () => {


### PR DESCRIPTION
## Summary
- Replaces `document.querySelector<HTMLInputElement>('.item__name')` with a function-callback ref per item, indexed by item id
- After soft-delete, focuses the deleted item's next neighbor in render order, then previous, then the add-item input as a fallback
- Removes the implicit coupling to a CSS class name and to DOM order — focus management is now deterministic and survives template/class restructuring

Closes #58

## Test plan
- [x] `npx vitest run tests/unit/views/List.spec.ts` — 15/15 passing (3 new focus tests using `attachTo: document.body` + real `document.activeElement` assertions)
- [x] `npx vitest run` — 178/178 passing
- [x] `npm run lint` — clean
- [x] Manual verification via dev server not performed; JSDOM-based focus assertions cover the behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)