### PR TITLE
refactor(list): extract ListItem + memoize filter groups (#38)

### DIFF
--- a/src/components/ListItem.vue
+++ b/src/components/ListItem.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="item">
+    <label :for="`item-checkbox-${item.id}`" class="sr-only">{{ item.n }} Checked</label>
+    <div class="item__checkbox-wrap">
+      <input type="checkbox" :id="`item-checkbox-${item.id}`" :checked="!!item.c"
+             @input="$emit('toggle')"
+             class="item__checkbox"/>
+      <font-awesome-icon icon="check"
+                         :class="['item__checkbox__icon', { 'item__checkbox__icon--checked': checked }]"/>
+    </div>
+    <div class="item__container">
+      <div class="item__quantity">
+        <label :for="`item-qty-${item.id}`" class="sr-only">{{ item.n }} Quantity</label>
+        <input type="text" inputmode="decimal"
+               :id="`item-qty-${item.id}`"
+               :value="item.q"
+               class="item__quantity__input"
+               @change="$emit('update:quantity', $event)"/>
+      </div>
+      <label :for="`item-name-${item.id}`" class="sr-only">{{ item.n }} Name</label>
+      <input type="text"
+             :id="`item-name-${item.id}`"
+             :value="item.n"
+             :ref="nameRef"
+             class="item__name"
+             @change="$emit('update:name', $event)"/>
+      <button @click="$emit('delete')"
+              :aria-label="`Remove ${item.n} from this list`"
+              class="item__icon--delete">
+        <font-awesome-icon icon="times-circle"/>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type Item from '@/classes/Item'
+
+defineProps<{
+  item: Item
+  checked: boolean
+  nameRef: (el: unknown) => void
+}>()
+
+defineEmits<{
+  (e: 'toggle'): void
+  (e: 'delete'): void
+  (e: 'update:name', event: Event): void
+  (e: 'update:quantity', event: Event): void
+}>()
+</script>

--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -28,84 +28,33 @@
     </form>
 
     <!-- Only display the list items if they are present and not all soft deleted. -->
-    <div
-      v-if=" list.i.length !== 0 &&
-      list.i.filter(item => item.d).length !== list.i.length"
-      class="items">
-      <div
-        v-if="list.i.filter(i => !i.d && !i.c).length === 0"
-        class="all-checked">😃 You've checked off all your items, nice!
+    <div v-if="hasAnyItems" class="items">
+      <div v-if="pendingItems.length === 0" class="all-checked">
+        😃 You've checked off all your items, nice!
       </div>
-      <div v-for="item in list.i.filter(i => !i.d && !i.c)" :key="item.id">
-        <div class="item">
-          <label :for="`item-checkbox-${item.id}`" class="sr-only">{{ item.n }} Checked</label>
-          <div class="item__checkbox-wrap">
-            <input type="checkbox" :id="`item-checkbox-${item.id}`" :checked="!!item.c"
-                   @input="toggleItemCheckedStatus(item.id)"
-                   class="item__checkbox"/>
-            <font-awesome-icon icon="check" class="item__checkbox__icon"/>
-          </div>
-          <div class="item__container">
-            <div class="item__quantity">
-              <label :for="`item-qty-${item.id}`" class="sr-only">{{ item.n }} Quantity</label>
-              <input type="text" inputmode="decimal"
-                     :id="`item-qty-${item.id}`"
-                     :value="item.q"
-                     class="item__quantity__input"
-                     @change="modifyItemQuantity($event, item.id)"/>
-            </div>
-            <label :for="`item-name-${item.id}`" class="sr-only">{{ item.n }} Name</label>
-            <input type="text"
-                   :id="`item-name-${item.id}`"
-                   :value="item.n"
-                   :ref="setItemNameRef(item.id)"
-                   class="item__name"
-                   @change="modifyItemName($event, item.id)"/>
-            <button @click="deleteItem(item.id)"
-                    :aria-label="`Remove ${item.n} from this list`"
-                    class="item__icon--delete">
-              <font-awesome-icon icon="times-circle"/>
-            </button>
-          </div>
-        </div>
-      </div>
+      <list-item v-for="item in pendingItems"
+                 :key="item.id"
+                 :item="item"
+                 :checked="false"
+                 :name-ref="setItemNameRef(item.id)"
+                 @toggle="toggleItemCheckedStatus(item.id)"
+                 @delete="deleteItem(item.id)"
+                 @update:name="modifyItemName($event, item.id)"
+                 @update:quantity="modifyItemQuantity($event, item.id)"/>
 
-      <h2 v-if="list.i.filter(i => !i.d && i.c === 1).length" class="items__h2">Checked Items</h2>
-      <div v-for="item in list.i.filter(i => !i.d && i.c === 1)" :key="item.id" class="items__checked">
-        <div class="item">
-          <label :for="`item-checkbox-${item.id}`" class="sr-only">{{ item.n }} Checked</label>
-          <div class="item__checkbox-wrap">
-            <input type="checkbox" :id="`item-checkbox-${item.id}`" :checked="!!item.c"
-                   @input="toggleItemCheckedStatus(item.id)"
-                   class="item__checkbox"/>
-            <font-awesome-icon icon="check" class="item__checkbox__icon item__checkbox__icon--checked"/>
-          </div>
-          <div class="item__container">
-            <div class="item__quantity">
-              <label :for="`item-qty-${item.id}`" class="sr-only">{{ item.n }} Quantity</label>
-              <input type="text" inputmode="decimal"
-                     :id="`item-qty-${item.id}`"
-                     :value="item.q"
-                     class="item__quantity__input"
-                     @change="modifyItemQuantity($event, item.id)"/>
-            </div>
-            <label :for="`item-name-${item.id}`" class="sr-only">{{ item.n }} Name</label>
-            <input type="text"
-                   :id="`item-name-${item.id}`"
-                   :value="item.n"
-                   :ref="setItemNameRef(item.id)"
-                   class="item__name"
-                   @change="modifyItemName($event, item.id)"/>
-            <button @click="deleteItem(item.id)"
-                    :aria-label="`Remove ${item.n} from this list`"
-                    class="item__icon--delete">
-              <font-awesome-icon icon="times-circle"/>
-            </button>
-          </div>
-        </div>
-      </div>
+      <h2 v-if="checkedItems.length" class="items__h2">Checked Items</h2>
+      <list-item v-for="item in checkedItems"
+                 :key="item.id"
+                 :item="item"
+                 :checked="true"
+                 :name-ref="setItemNameRef(item.id)"
+                 class="items__checked"
+                 @toggle="toggleItemCheckedStatus(item.id)"
+                 @delete="deleteItem(item.id)"
+                 @update:name="modifyItemName($event, item.id)"
+                 @update:quantity="modifyItemQuantity($event, item.id)"/>
     </div>
-    <div v-if="list.i.filter(i => !i.d).length === 0" class="no-items">Add items to this list above.</div>
+    <div v-if="!hasAnyItems" class="no-items">Add items to this list above.</div>
   </div>
 
   <share-sheet v-if="shareList"
@@ -122,6 +71,7 @@ import { useRoute, useRouter } from 'vue-router'
 import Item from '@/classes/Item'
 import { useListsStore } from '@/stores/lists'
 import { useLiveRegion } from '@/composables/useLiveRegion'
+import ListItem from '@/components/ListItem.vue'
 import ShareSheet from '@/components/ShareSheet.vue'
 import type List from '@/classes/List'
 
@@ -132,6 +82,10 @@ const { announce } = useLiveRegion()
 
 const listId = computed(() => route.params.id as string)
 const list = computed(() => listsStore.getListFromId(listId.value))
+const activeItems = computed(() => list.value?.i.filter(i => !i.d) ?? [])
+const pendingItems = computed(() => activeItems.value.filter(i => !i.c))
+const checkedItems = computed(() => activeItems.value.filter(i => i.c === 1))
+const hasAnyItems = computed(() => activeItems.value.length > 0)
 const name = ref<string | null>(null)
 const quantity = ref<number>(1)
 const itemName = ref<HTMLInputElement | null>(null)
@@ -199,10 +153,7 @@ async function deleteItem (id: string): Promise<void> {
 
   // Capture render-order snapshot BEFORE mutating so we can pick the
   // deleted item's neighbor deterministically.
-  const active = list.value!.i.filter(i => !i.d)
-  const pending = active.filter(i => !i.c)
-  const checked = active.filter(i => i.c === 1)
-  const renderOrder = [...pending, ...checked]
+  const renderOrder = [...pendingItems.value, ...checkedItems.value]
   const idx = renderOrder.findIndex(i => i.id === id)
   const neighbor = renderOrder[idx + 1] ?? renderOrder[idx - 1]
 

--- a/tests/unit/components/ListItem.spec.ts
+++ b/tests/unit/components/ListItem.spec.ts
@@ -1,0 +1,59 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import ListItem from '@/components/ListItem.vue'
+
+const makeItem = (overrides = {}) => ({
+  id: 'item1', n: 'Apples', q: '2', c: 0, d: 0, u: 0, ...overrides
+})
+
+const mountItem = (props = {}) => mount(ListItem, {
+  props: { item: makeItem(), checked: false, nameRef: () => {}, ...props },
+  global: { stubs: { FontAwesomeIcon: { template: '<span/>' } } }
+})
+
+describe('ListItem.vue', () => {
+  it('renders the item name and quantity', () => {
+    const wrapper = mountItem()
+    expect((wrapper.find('.item__name').element as HTMLInputElement).value).toBe('Apples')
+    expect((wrapper.find('.item__quantity__input').element as HTMLInputElement).value).toBe('2')
+  })
+
+  it('emits toggle when the checkbox is clicked', async () => {
+    const wrapper = mountItem()
+    await wrapper.find('input[type="checkbox"]').trigger('input')
+    expect(wrapper.emitted('toggle')).toHaveLength(1)
+  })
+
+  it('emits delete when the delete button is clicked', async () => {
+    const wrapper = mountItem()
+    await wrapper.find('.item__icon--delete').trigger('click')
+    expect(wrapper.emitted('delete')).toHaveLength(1)
+  })
+
+  it('emits update:name on the name input change event', async () => {
+    const wrapper = mountItem()
+    await wrapper.find('.item__name').setValue('Oranges')
+    expect(wrapper.emitted('update:name')).toBeTruthy()
+  })
+
+  it('emits update:quantity on the quantity input change event', async () => {
+    const wrapper = mountItem()
+    await wrapper.find('.item__quantity__input').setValue('5')
+    expect(wrapper.emitted('update:quantity')).toBeTruthy()
+  })
+
+  it('applies the checkbox-icon--checked class when checked is true', () => {
+    const wrapper = mountItem({ checked: true })
+    expect(wrapper.html()).toContain('item__checkbox__icon--checked')
+  })
+
+  it('invokes the nameRef callback with the input element', () => {
+    const calls: unknown[] = []
+    const nameRef = vi.fn((el: unknown) => calls.push(el))
+    mountItem({ nameRef })
+    expect(nameRef).toHaveBeenCalled()
+    const received = calls.find(c => c instanceof HTMLInputElement) as HTMLInputElement
+    expect(received).toBeTruthy()
+    expect(received.classList.contains('item__name')).toBe(true)
+  })
+})


### PR DESCRIPTION
> **Stacked on top of #85** (`fix/list-focus-vue-refs-issue-58`). Targeted at that branch — will retarget to `main` automatically once #85 merges.

## Summary
- Extracts a `<ListItem>` sub-component to absorb the duplicated ~60-line item markup that previously rendered twice in `List.vue` (unchecked + checked sections)
- Replaces the six inline `list.i.filter(...)` calls in the template with three computed groups: `activeItems`, `pendingItems`, `checkedItems`, plus `hasAnyItems`
- The new component takes the item, a `checked` flag (drives the icon variant), and a `nameRef` callback so the focus-management map from #58 keeps working transparently
- Item SCSS stays in `List.vue` so the `.items__checked .item__container` strikethrough cascade still applies cleanly

Closes #38

## Test plan
- [x] `npx vitest run` — 185/185 passing (7 new `ListItem.spec.ts` cases + existing `List.spec.ts` suite incl. focus tests still green)
- [x] `npm run lint` — clean
- [x] `npm run build` — type-check + bundle succeed
- [x] `npm run test:e2e` smoke — 7/8 pass; the 1 failure is a pre-existing flake on `a11y: List route — initial state` that reproduces on `main` (color-contrast on `.new-item__button`, unrelated CSS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)