### PR TITLE
fix(list-view): guard missing item in modifyItemQuantity (#92)

### DIFF
--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -131,7 +131,8 @@ function addItemToList (): void {
 
 function modifyItemQuantity (event: Event, id: string): void {
   const input = event.target as HTMLInputElement
-  const item = list.value!.i.find(i => i.id === id)!
+  const item = list.value!.i.find(i => i.id === id)
+  if (!item) return
   if (input.value && !isNaN(Number(input.value))) {
     listsStore.updateItem(listId.value, id, { q: input.value })
   } else {

--- a/tests/unit/views/List.spec.ts
+++ b/tests/unit/views/List.spec.ts
@@ -132,6 +132,14 @@ describe('List.vue', () => {
     expect(store.lists[0].i[0].q).toBe('5')
   })
 
+  it('does not crash if the quantity-change event fires for a missing item id', async () => {
+    const { wrapper, store } = await mountList()
+    const qtyInput = wrapper.find('.item__quantity__input')
+    // Remove the underlying item between the input event and the change handler.
+    store.$patch({ lists: [{ id: listId, n: 'Groceries', i: [] }] })
+    expect(() => qtyInput.element.dispatchEvent(new Event('change'))).not.toThrow()
+  })
+
   it('shows the all-checked banner when every active item is checked', async () => {
     const { wrapper } = await mountList([makeItem({ c: 1 })])
     expect(wrapper.text()).toContain('checked off all your items')


### PR DESCRIPTION
## Summary
- `modifyItemQuantity` chained a trailing `!` onto `.find()`, so a change event for an item that was deleted between dispatch and handler (e.g. via the same render frame) would throw on the next property access.
- Drop the assertion, return early on miss, and add a regression test that empties the store before firing `change`.

Fixes #92

## Test plan
- [x] `npm run test:unit` — `List.vue` suite passes (16 tests, +1 regression case)
- [x] `npx eslint src/views/List.vue tests/unit/views/List.spec.ts` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)