### PR TITLE
fix(list-view): reject empty/whitespace quantity input (#95)

### DIFF
--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -133,8 +133,9 @@ function modifyItemQuantity (event: Event, id: string): void {
   const input = event.target as HTMLInputElement
   const item = list.value!.i.find(i => i.id === id)
   if (!item) return
-  if (input.value && !isNaN(Number(input.value))) {
-    listsStore.updateItem(listId.value, id, { q: input.value })
+  const trimmed = input.value.trim()
+  if (trimmed !== '' && !isNaN(Number(trimmed))) {
+    listsStore.updateItem(listId.value, id, { q: trimmed })
   } else {
     input.value = item.q
   }

--- a/tests/unit/views/List.spec.ts
+++ b/tests/unit/views/List.spec.ts
@@ -140,6 +140,15 @@ describe('List.vue', () => {
     expect(() => qtyInput.element.dispatchEvent(new Event('change'))).not.toThrow()
   })
 
+  it('reverts to the previous quantity when input is whitespace-only', async () => {
+    const { wrapper, store } = await mountList()
+    const qtyInput = wrapper.find<HTMLInputElement>('.item__quantity__input')
+    await qtyInput.setValue('   ')
+    await qtyInput.trigger('change')
+    expect(store.lists[0].i[0].q).toBe('2')
+    expect(qtyInput.element.value).toBe('2')
+  })
+
   it('shows the all-checked banner when every active item is checked', async () => {
     const { wrapper } = await mountList([makeItem({ c: 1 })])
     expect(wrapper.text()).toContain('checked off all your items')


### PR DESCRIPTION
## Summary
- `Number('')` is `0`, so the prior guard `input.value && !isNaN(Number(input.value))` accepted any whitespace-only string as a valid quantity (truthy + `Number('  ') === 0`).
- Trim first; only accept the input when the trimmed value is non-empty and numeric, otherwise revert to the previous quantity.

Fixes #95

Note: lightly conflicts with #114 (issue #92) on the same `modifyItemQuantity` block — whichever merges first will require a trivial rebase of the other.

## Test plan
- [x] `npm run test:unit` — `List.vue` suite (16 tests, +1 regression for whitespace input)
- [x] `npx eslint` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)