### PR TITLE
fix(sync-types): declare version on JoinResponse (#93)

### DIFF
--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -32,6 +32,7 @@ export interface JoinResponse {
   listId: string
   role: 'owner' | 'editor'
   name: string
+  version: number
   cursor: number
   items: ItemPayload[]
 }

--- a/tests/unit/sync/provision-join.spec.ts
+++ b/tests/unit/sync/provision-join.spec.ts
@@ -95,7 +95,7 @@ describe('sync/index — join', () => {
   })
 
   it('applies payload, saves meta, starts poller, and returns true', async () => {
-    const data = { listId: 'list2', role: 'editor' as const, name: 'Shared', cursor: 1700, items: [] }
+    const data = { listId: 'list2', role: 'editor' as const, name: 'Shared', version: 1, cursor: 1700, items: [] }
     mJoinList.mockResolvedValue({ ok: true, data })
 
     expect(await join('list2', 'tok2')).toBe(true)

--- a/tests/unit/sync/reconcile.spec.ts
+++ b/tests/unit/sync/reconcile.spec.ts
@@ -35,7 +35,7 @@ describe('sync/reconcile', () => {
   describe('applyJoinPayload', () => {
     it('inserts the incoming list when absent', () => {
       const store = useListsStore()
-      applyJoinPayload({ listId: 's1', role: 'editor', name: 'Shared', cursor: 5, items: [ITEM] })
+      applyJoinPayload({ listId: 's1', role: 'editor', name: 'Shared', version: 1, cursor: 5, items: [ITEM] })
       expect(store.lists).toHaveLength(1)
       expect(store.lists[0].n).toBe('Shared')
       expect(store.lists[0].i[0].n).toBe('Milk')
@@ -44,7 +44,7 @@ describe('sync/reconcile', () => {
     it('replaces an existing list with the same id', () => {
       const store = useListsStore()
       store.$patch({ lists: [{ id: 's1', n: 'Old', i: [] }] })
-      applyJoinPayload({ listId: 's1', role: 'editor', name: 'Updated', cursor: 2, items: [] })
+      applyJoinPayload({ listId: 's1', role: 'editor', name: 'Updated', version: 2, cursor: 2, items: [] })
       expect(store.lists).toHaveLength(1)
       expect(store.lists[0].n).toBe('Updated')
     })


### PR DESCRIPTION
## Summary
- `handleJoin` returns `version`, but the client `JoinResponse` did not declare it — the field was silently lost at the type boundary.
- Add `version: number`. Update unit fixtures in `provision-join.spec.ts` and `reconcile.spec.ts` that construct `JoinResponse` literals to include the new field.

Fixes #93

## Test plan
- [x] `npx vue-tsc --noEmit` clean
- [x] `npm run test:unit` — sync suites all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)