### PR TITLE
fix(api): reject NaN/negative since on poll endpoint (#91)

### DIFF
--- a/functions/api/_shared/handlers.ts
+++ b/functions/api/_shared/handlers.ts
@@ -92,7 +92,11 @@ export async function handlePoll (
   if (auth instanceof Response) return auth
 
   const url = new URL(request.url)
-  const since = parseInt(url.searchParams.get('since') ?? '0', 10)
+  const sinceRaw = url.searchParams.get('since')
+  const since = sinceRaw === null ? 0 : Number(sinceRaw)
+  if (!Number.isInteger(since) || since < 0) {
+    return Response.json({ error: 'invalid since' }, { status: 400 })
+  }
 
   const list = await db.prepare(
     'SELECT id, name, u, version FROM lists WHERE id = ?'

--- a/tests/integration/api/lists.spec.ts
+++ b/tests/integration/api/lists.spec.ts
@@ -326,6 +326,24 @@ describe('GET /api/lists/:id?since=', () => {
     const res = await handlePoll(db, req, '01JVKZ00000000000000000000')
     expect(res.status).toBe(401) // token not valid for this list
   })
+
+  it('rejects non-numeric since with 400', async () => {
+    const { id, authToken } = await provision()
+    const req = new Request(`http://localhost/api/lists/${id}?since=abc`, {
+      headers: { Authorization: `Bearer ${authToken}` }
+    })
+    const res = await handlePoll(db, req, id)
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects negative since with 400', async () => {
+    const { id, authToken } = await provision()
+    const req = new Request(`http://localhost/api/lists/${id}?since=-1`, {
+      headers: { Authorization: `Bearer ${authToken}` }
+    })
+    const res = await handlePoll(db, req, id)
+    expect(res.status).toBe(400)
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `parseInt('abc', 10)` is `NaN`, which flowed unchecked into D1 as the lower bound for `items.u > ?`. Same for negatives.
- Parse with `Number()` and reject any value that isn't a non-negative integer with `400 invalid since` before touching the DB.

Fixes #91

## Test plan
- [x] `npm run test:integration` — 42 tests, +2 regression cases (`?since=abc`, `?since=-1` → 400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)