### PR TITLE
fix(sync): clean up visibilitychange listener on stopPoller (#89)

### DIFF
--- a/src/sync/poll.ts
+++ b/src/sync/poll.ts
@@ -11,13 +11,14 @@ const MAX_BACKOFF_MS = 60_000
 interface PollState {
   stopped: boolean
   backoff: number
+  cleanup: (() => void) | null
 }
 
 const activePollers = new Map<string, PollState>()
 
 export function startPoller (listId: string): void {
   if (activePollers.has(listId)) return
-  const state: PollState = { stopped: false, backoff: 1_000 }
+  const state: PollState = { stopped: false, backoff: 1_000, cleanup: null }
   activePollers.set(listId, state)
   void runPoller(listId, state)
 }
@@ -26,6 +27,8 @@ export function stopPoller (listId: string): void {
   const state = activePollers.get(listId)
   if (state) {
     state.stopped = true
+    state.cleanup?.()
+    state.cleanup = null
     activePollers.delete(listId)
   }
 }
@@ -34,14 +37,22 @@ async function sleep (ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-async function waitVisible (): Promise<void> {
+async function waitVisible (state: PollState): Promise<void> {
   if (!document.hidden) return
   return new Promise(resolve => {
+    const cleanup = () => {
+      document.removeEventListener('visibilitychange', onVisible)
+      state.cleanup = null
+    }
     const onVisible = () => {
       if (!document.hidden) {
-        document.removeEventListener('visibilitychange', onVisible)
+        cleanup()
         resolve()
       }
+    }
+    state.cleanup = () => {
+      cleanup()
+      resolve()
     }
     document.addEventListener('visibilitychange', onVisible)
   })
@@ -49,7 +60,7 @@ async function waitVisible (): Promise<void> {
 
 async function runPoller (listId: string, state: PollState): Promise<void> {
   while (!state.stopped) {
-    await waitVisible()
+    await waitVisible(state)
     if (state.stopped) break
 
     const meta = getMeta(listId)

--- a/tests/unit/sync/poll.spec.ts
+++ b/tests/unit/sync/poll.spec.ts
@@ -95,6 +95,28 @@ describe('sync/poll', () => {
     expect(vi.mocked(applyPollPayload)).not.toHaveBeenCalled()
   })
 
+  it('stopPoller: removes the visibilitychange listener registered while hidden', async () => {
+    const hiddenDesc = Object.getOwnPropertyDescriptor(Document.prototype, 'hidden')
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => true })
+    const addSpy = vi.spyOn(document, 'addEventListener')
+    const removeSpy = vi.spyOn(document, 'removeEventListener')
+    try {
+      mGetMeta.mockReturnValue({ authToken: 'tok', lastCursor: 0, role: 'owner' })
+      startPoller('vis1')
+      await Promise.resolve()
+      const visAdds = addSpy.mock.calls.filter(([type]) => type === 'visibilitychange')
+      expect(visAdds.length).toBeGreaterThan(0)
+
+      stopPoller('vis1')
+      const visRemoves = removeSpy.mock.calls.filter(([type]) => type === 'visibilitychange')
+      expect(visRemoves.length).toBe(visAdds.length)
+    } finally {
+      if (hiddenDesc) Object.defineProperty(document, 'hidden', hiddenDesc)
+      addSpy.mockRestore()
+      removeSpy.mockRestore()
+    }
+  })
+
   it('runPoller: backs off and retries on network error', async () => {
     mGetMeta
       .mockReturnValueOnce({ authToken: 'tok', lastCursor: 0, role: 'owner' })


### PR DESCRIPTION
## Summary
- `waitVisible` registered a `visibilitychange` listener when the tab was hidden, but only removed it via its own callback. If `stopPoller` was invoked while the tab was still hidden, the listener stayed on `document` (and the inner promise never resolved).
- Store a per-poller `cleanup` on `PollState` while the listener is pending and invoke it from `stopPoller`. Repeated start/stop cycles now leave no residual listeners.

Fixes #89

## Test plan
- [x] `npm run test:unit` — `sync/poll` suite, +1 regression case asserting add/remove count parity around `start` + `stop` while `document.hidden` is true

🤖 Generated with [Claude Code](https://claude.com/claude-code)