### PR TITLE
fix(theme): expose cleanup to drop matchMedia listener (#90)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -28,7 +28,7 @@ const router = useRouter()
 const listsStore = useListsStore()
 const loaded = ref(false)
 const { message: liveMessage, announce } = useLiveRegion()
-const { init: initTheme } = useTheme()
+const { init: initTheme, cleanup: cleanupTheme } = useTheme()
 
 async function handleJoinFragment () {
   const m = /^#join=([^.]+)\.(.+)$/.exec(window.location.hash)
@@ -61,6 +61,7 @@ onMounted(async () => {
 
 onUnmounted(() => {
   window.removeEventListener('hashchange', handleJoinFragment)
+  cleanupTheme()
 })
 </script>
 

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -41,6 +41,13 @@ function init () {
   apply(mode.value)
 }
 
+function cleanup () {
+  if (!initialized) return
+  mq?.removeEventListener('change', onMediaChange)
+  mq = null
+  initialized = false
+}
+
 export function useTheme () {
-  return { mode: readonly(mode), setMode, cycleMode, init }
+  return { mode: readonly(mode), setMode, cycleMode, init, cleanup }
 }

--- a/tests/unit/composables/useTheme.spec.ts
+++ b/tests/unit/composables/useTheme.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 let mockMatches = false
 const mockAddEventListener = vi.fn()
+const mockRemoveEventListener = vi.fn()
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
@@ -9,7 +10,7 @@ Object.defineProperty(window, 'matchMedia', {
     matches: mockMatches,
     media: query,
     addEventListener: mockAddEventListener,
-    removeEventListener: vi.fn(),
+    removeEventListener: mockRemoveEventListener,
     dispatchEvent: vi.fn()
   }))
 })
@@ -26,6 +27,7 @@ describe('useTheme', () => {
     document.documentElement.classList.remove('dark')
     mockMatches = false
     mockAddEventListener.mockClear()
+    mockRemoveEventListener.mockClear()
   })
 
   describe('init', () => {
@@ -77,6 +79,30 @@ describe('useTheme', () => {
       init()
       init()
       expect(mockAddEventListener).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('cleanup', () => {
+    it('removes the matchMedia listener registered by init()', async () => {
+      const { init, cleanup } = await freshTheme()
+      init()
+      const [, handler] = mockAddEventListener.mock.calls[0]
+      cleanup()
+      expect(mockRemoveEventListener).toHaveBeenCalledWith('change', handler)
+    })
+
+    it('is a no-op when init() was never called', async () => {
+      const { cleanup } = await freshTheme()
+      cleanup()
+      expect(mockRemoveEventListener).not.toHaveBeenCalled()
+    })
+
+    it('allows init() to re-register after cleanup (e.g. HMR)', async () => {
+      const { init, cleanup } = await freshTheme()
+      init()
+      cleanup()
+      init()
+      expect(mockAddEventListener).toHaveBeenCalledTimes(2)
     })
   })
 


### PR DESCRIPTION
## Summary
- `useTheme().init()` added a `MediaQueryList` `change` listener that was never removed. HMR/repeated mounts therefore stacked listeners.
- Add a paired `cleanup()` that removes the listener and resets the module-local `initialized` flag so a subsequent `init()` re-registers cleanly. Wire `App.vue#onUnmounted` to call it.

Fixes #90

## Test plan
- [x] `npm run test:unit` — `useTheme` suite, +3 regression cases (remove on cleanup, no-op without init, re-init after cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)