### PR TITLE
fix(sync): identify queue ops by opId to survive cross-tab races (#94)

### DIFF
--- a/src/sync/queue.ts
+++ b/src/sync/queue.ts
@@ -4,7 +4,7 @@ import { getMeta } from './storage'
 import { upsertItem } from './transport'
 import { reconcileServerItem } from './reconcile'
 import { cleanupListLocally } from './cleanup'
-import type { Op } from './types'
+import type { Op, UpsertItemOp } from './types'
 
 const QUEUE_KEY = 'pendingOps'
 const MAX_BACKOFF_MS = 60_000
@@ -13,16 +13,35 @@ let flushRunning = false
 let backoffMs = 1_000
 
 function loadQueue (): Op[] {
-  try { return JSON.parse(localStorage.getItem(QUEUE_KEY) ?? '[]') as Op[] } catch { return [] }
+  try {
+    const raw = JSON.parse(localStorage.getItem(QUEUE_KEY) ?? '[]') as Array<Op & { opId?: string }>
+    let migrated = false
+    for (const op of raw) {
+      if (!op.opId) {
+        op.opId = crypto.randomUUID()
+        migrated = true
+      }
+    }
+    if (migrated) saveQueue(raw as Op[])
+    return raw as Op[]
+  } catch { return [] }
 }
 
 function saveQueue (q: Op[]): void {
   localStorage.setItem(QUEUE_KEY, JSON.stringify(q))
 }
 
-export function enqueue (op: Op): void {
+function removeOpById (opId: string): void {
+  saveQueue(loadQueue().filter(o => o.opId !== opId))
+}
+
+function removeOpsByListId (listId: string): void {
+  saveQueue(loadQueue().filter(o => o.listId !== listId))
+}
+
+export function enqueue (op: Omit<UpsertItemOp, 'opId'>): void {
   const q = loadQueue()
-  q.push(op)
+  q.push({ ...op, opId: crypto.randomUUID() })
   saveQueue(q)
   scheduleFlush()
 }
@@ -58,7 +77,7 @@ async function flush (): Promise<void> {
     const op = q[0]
     const meta = getMeta(op.listId)
     if (!meta) {
-      saveQueue(q.filter(o => o.listId !== op.listId))
+      removeOpsByListId(op.listId)
       continue
     }
 
@@ -67,7 +86,7 @@ async function flush (): Promise<void> {
     if (result.ok) {
       backoffMs = 1_000
       reconcileServerItem(op.listId, result.data.item)
-      saveQueue(loadQueue().slice(1))
+      removeOpById(op.opId)
     } else if (
       result.error.kind === 'unauthorized' ||
       result.error.kind === 'not-found'
@@ -79,7 +98,7 @@ async function flush (): Promise<void> {
           : `"${listName}" was deleted.`,
         'error'
       )
-      saveQueue(loadQueue().filter(o => o.listId !== op.listId))
+      removeOpsByListId(op.listId)
       cleanupListLocally(op.listId)
     } else {
       await sleep(backoffMs)

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -46,6 +46,7 @@ export interface MintTokenResponse {
 
 export interface UpsertItemOp {
   kind: 'upsertItem'
+  opId: string
   listId: string
   item: ItemPayload
 }

--- a/tests/unit/sync/queue.spec.ts
+++ b/tests/unit/sync/queue.spec.ts
@@ -85,6 +85,47 @@ describe('enqueue', () => {
   })
 })
 
+describe('flush — concurrent-tab race', () => {
+  it('removes only the processed op by opId, preserving concurrent appends', async () => {
+    vi.mocked(getMeta).mockReturnValue(META)
+
+    let resolveFirst!: (v: { ok: true; data: { item: typeof ITEM } }) => void
+    vi.mocked(upsertItem)
+      .mockImplementationOnce(() => new Promise(resolve => {
+        resolveFirst = resolve as typeof resolveFirst
+      }))
+      // The sibling op blocks forever — we just want to snapshot localStorage
+      // after the first removal but before the loop processes the next op.
+      .mockImplementation(() => new Promise(() => {}))
+    mockStore({ getListFromId: vi.fn().mockReturnValue({ id: 'list1', n: 'G', i: [] }) })
+
+    enqueue({ kind: 'upsertItem', listId: 'list1', item: ITEM })
+    await Promise.resolve()
+
+    // Simulate another tab appending an op during the in-flight upsert.
+    const inFlight = JSON.parse(localStorage.getItem('pendingOps') ?? '[]') as Array<{ opId: string }>
+    const sibling = { kind: 'upsertItem', opId: 'sibling-from-other-tab', listId: 'list1', item: { ...ITEM, id: 'sibling' } }
+    localStorage.setItem('pendingOps', JSON.stringify([...inFlight, sibling]))
+
+    resolveFirst({ ok: true, data: { item: ITEM } })
+    await vi.runAllTimersAsync()
+
+    const q = JSON.parse(localStorage.getItem('pendingOps') ?? '[]') as Array<{ opId: string }>
+    expect(q.map(o => o.opId)).toEqual(['sibling-from-other-tab'])
+  })
+
+  it('migrates legacy queue entries without opId on load', () => {
+    localStorage.setItem('pendingOps', JSON.stringify([{ kind: 'upsertItem', listId: 'list1', item: ITEM }]))
+    vi.mocked(getMeta).mockReturnValue(META)
+    vi.mocked(upsertItem).mockReturnValue(new Promise(() => {}))
+    startDrainer()
+    const q = JSON.parse(localStorage.getItem('pendingOps') ?? '[]') as Array<{ opId?: string }>
+    expect(q).toHaveLength(1)
+    expect(typeof q[0].opId).toBe('string')
+    expect((q[0].opId ?? '').length).toBeGreaterThan(0)
+  })
+})
+
 describe('flush — success path', () => {
   it('removes head op and calls reconcileServerItem on success', async () => {
     vi.mocked(getMeta).mockReturnValue(META)


### PR DESCRIPTION
## Summary
- The flush loop used positional removal (`loadQueue().slice(1)` and list-id filtering). With two tabs both touching `localStorage[pendingOps]`, a sibling tab's enqueue between this tab's read and write was silently lost (read `[opA]`, sibling writes `[opA, opB]`, original write `[].slice(1) = []`).
- Stamp every op with a `crypto.randomUUID()` `opId` at enqueue time. Two new helpers — `removeOpById` and `removeOpsByListId` — re-read the latest queue from storage and filter by identity before saving, so concurrent appends from other tabs survive.
- Migrate any legacy entries missing `opId` on first load (assigned + persisted).
- `enqueue` takes `Omit<UpsertItemOp, 'opId'>` so call sites in `stores/lists.ts` are unchanged.

Fixes #94

## Test plan
- [x] `npx vue-tsc --noEmit` clean
- [x] `npm run test:unit` — 187 tests, +2 queue regressions:
  - Sibling op appended mid-flight is preserved across the head removal
  - Legacy entries without `opId` gain one on read
- [x] `npm run lint` clean on touched files

Conflicts lightly with #116 (issue #93) on `src/sync/types.ts`; trivial rebase after either lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)