### PR TITLE
fix(new): await router.push and surface navigation errors (#103)

### DIFF
--- a/src/views/New.vue
+++ b/src/views/New.vue
@@ -19,22 +19,29 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, isNavigationFailure, NavigationFailureType } from 'vue-router'
 import List from '@/classes/List'
 import { useListsStore } from '@/stores/lists'
+import { useToastStore } from '@/stores/toast'
 
 const router = useRouter()
 const listsStore = useListsStore()
+const toastStore = useToastStore()
 
 const name = ref<string | null>(null)
 const newListName = ref<HTMLInputElement | null>(null)
 
-function createList (): void {
+async function createList (): Promise<void> {
   const list = listsStore.createList(new List(name.value!, []))
-  router.push({
-    name: 'List',
-    params: { id: list.id }
-  })
+  try {
+    await router.push({
+      name: 'List',
+      params: { id: list.id }
+    })
+  } catch (err) {
+    if (isNavigationFailure(err, NavigationFailureType.duplicated)) return
+    toastStore.add('Could not open the new list.', 'error')
+  }
 }
 
 onMounted(() => {

--- a/tests/unit/views/New.spec.ts
+++ b/tests/unit/views/New.spec.ts
@@ -1,19 +1,24 @@
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import { describe, it, expect, vi } from 'vitest'
 import { useListsStore } from '@/stores/lists'
+import { useToastStore } from '@/stores/toast'
 import New from '@/views/New.vue'
+
+function makeRouter () {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'New', component: { template: '<div/>' } },
+      { path: '/list/:id', name: 'List', component: { template: '<div/>' } }
+    ]
+  })
+}
 
 describe('New.vue', () => {
   it('creates a list and navigates on submit', async () => {
-    const router = createRouter({
-      history: createMemoryHistory(),
-      routes: [
-        { path: '/', name: 'New', component: { template: '<div/>' } },
-        { path: '/list/:id', name: 'List', component: { template: '<div/>' } }
-      ]
-    })
+    const router = makeRouter()
     const push = vi.spyOn(router, 'push')
 
     const wrapper = mount(New, {
@@ -27,6 +32,7 @@ describe('New.vue', () => {
     })
     await wrapper.find('input#name').setValue('My List')
     await wrapper.find('form').trigger('submit')
+    await flushPromises()
     const store = useListsStore()
     expect(store.lists).toHaveLength(1)
     expect(store.lists[0].n).toBe('My List')
@@ -34,5 +40,26 @@ describe('New.vue', () => {
       name: 'List',
       params: { id: store.lists[0].id }
     })
+  })
+
+  it('surfaces a toast when navigation rejects', async () => {
+    const router = makeRouter()
+    vi.spyOn(router, 'push').mockRejectedValueOnce(new Error('boom'))
+
+    const wrapper = mount(New, {
+      global: {
+        plugins: [
+          createTestingPinia({ stubActions: false, initialState: { lists: { lists: [] } } }),
+          router
+        ],
+        stubs: { RouterLink: { template: '<a><slot /></a>' } }
+      }
+    })
+    const toast = useToastStore()
+    await wrapper.find('input#name').setValue('My List')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+    expect(toast.toasts).toHaveLength(1)
+    expect(toast.toasts[0].type).toBe('error')
   })
 })


### PR DESCRIPTION
## Summary
- `router.push` in `New.vue#createList` was returning an unawaited promise, so navigation failures after creating a list were silently swallowed.
- Await the call inside a try/catch, ignore the benign `duplicated` navigation result, and surface real failures as an error toast.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test:unit` (added rejection-path test for `New.vue`)
- [x] `npm run build`

Fixes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)