### PR TITLE
fix(api): reject whitespace-only list names on provision (#99)

### DIFF
--- a/functions/api/_shared/handlers.ts
+++ b/functions/api/_shared/handlers.ts
@@ -46,7 +46,11 @@ export async function handleProvision (db: D1Database, request: Request): Promis
   if (!parsed.ok) return Response.json({ error: parsed.error }, { status: parsed.status })
   const body = parsed.body
 
-  if (typeof body.name !== 'string' || body.name.length === 0 || body.name.length > LIMITS.listNameMax) {
+  if (typeof body.name !== 'string' || body.name.length > LIMITS.listNameMax) {
+    return Response.json({ error: 'name required' }, { status: 400 })
+  }
+  const name = body.name.trim()
+  if (name.length === 0) {
     return Response.json({ error: 'name required' }, { status: 400 })
   }
 
@@ -69,7 +73,7 @@ export async function handleProvision (db: D1Database, request: Request): Promis
   await db.batch([
     db.prepare(
       'INSERT INTO lists (id, name, u, version, created_at) VALUES (?, ?, 0, 1, ?)'
-    ).bind(listId, body.name, now),
+    ).bind(listId, name, now),
     db.prepare(
       'INSERT INTO list_tokens (token_hash, list_id, role, created_at) VALUES (?, ?, ?, ?)'
     ).bind(tokenHash, listId, 'owner', now),

--- a/tests/integration/api/lists.spec.ts
+++ b/tests/integration/api/lists.spec.ts
@@ -85,6 +85,37 @@ describe('POST /api/lists', () => {
     expect(res.status).toBe(400)
   })
 
+  it('returns 400 when name is empty or whitespace-only', async () => {
+    for (const name of ['', '   ', '\t\n ', ' ']) {
+      const req = new Request('http://localhost/api/lists', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, items: [] })
+      })
+      const res = await handleProvision(db, req)
+      expect(res.status).toBe(400)
+    }
+  })
+
+  it('stores trimmed list name', async () => {
+    const req = new Request('http://localhost/api/lists', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: '  Weekly Shop  ', items: [] })
+    })
+    const res = await handleProvision(db, req)
+    expect(res.status).toBe(200)
+    const { id, authToken } = await res.json() as { id: string; authToken: string }
+
+    const joinReq = new Request(`http://localhost/api/lists/${id}/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: authToken })
+    })
+    const body = await handleJoin(db, joinReq, id).then(r => r.json() as Promise<{ name: string }>)
+    expect(body.name).toBe('Weekly Shop')
+  })
+
   it('returns 400 for invalid JSON', async () => {
     const req = new Request('http://localhost/api/lists', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- `handleProvision` only checked `body.name.length === 0`, so names like `'   '` or `'\t'` were accepted and stored as blank list rows.
- Reject names whose trimmed length is zero with a 400, and persist the trimmed value to keep stored names clean.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run test:integration` (added empty/whitespace + trim tests)
- [x] `npm run build`

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)