### PR TITLE
fix(api): validate listId as ULID before DB lookup (#102)

### DIFF
--- a/functions/api/_shared/handlers.ts
+++ b/functions/api/_shared/handlers.ts
@@ -1,8 +1,12 @@
 import type { ItemRow, ListRow, TokenRow } from './types'
-import { generateUlid, generateToken } from './ulid'
+import { generateUlid, generateToken, isUlid } from './ulid'
 import { authenticate } from './auth'
 import { hashToken } from '../../../shared/crypto'
 import { LIMITS, readJsonBody, validateItem } from './validate'
+
+function invalidListId (): Response {
+  return Response.json({ error: 'invalid list id' }, { status: 400 })
+}
 
 export async function handleUpsertItem (
   db: D1Database,
@@ -10,6 +14,7 @@ export async function handleUpsertItem (
   listId: string,
   itemId: string
 ): Promise<Response> {
+  if (!isUlid(listId)) return invalidListId()
   const auth = await authenticate(db, request, listId)
   if (auth instanceof Response) return auth
 
@@ -88,6 +93,7 @@ export async function handlePoll (
   request: Request,
   listId: string
 ): Promise<Response> {
+  if (!isUlid(listId)) return invalidListId()
   const auth = await authenticate(db, request, listId)
   if (auth instanceof Response) return auth
 
@@ -128,6 +134,7 @@ export async function handleJoin (
   request: Request,
   listId: string
 ): Promise<Response> {
+  if (!isUlid(listId)) return invalidListId()
   const parsed = await readJsonBody<{ token?: unknown }>(request)
   if (!parsed.ok) return Response.json({ error: parsed.error }, { status: parsed.status })
   const body = parsed.body
@@ -173,6 +180,7 @@ export async function handleMintToken (
   request: Request,
   listId: string
 ): Promise<Response> {
+  if (!isUlid(listId)) return invalidListId()
   const auth = await authenticate(db, request, listId)
   if (auth instanceof Response) return auth
   if ((auth as TokenRow).role !== 'owner') {
@@ -195,6 +203,7 @@ export async function handleRevokeToken (
   request: Request,
   listId: string
 ): Promise<Response> {
+  if (!isUlid(listId)) return invalidListId()
   const auth = await authenticate(db, request, listId)
   if (auth instanceof Response) return auth
   if ((auth as TokenRow).role !== 'owner') {
@@ -213,6 +222,7 @@ export async function handleDeleteList (
   request: Request,
   listId: string
 ): Promise<Response> {
+  if (!isUlid(listId)) return invalidListId()
   const auth = await authenticate(db, request, listId)
   if (auth instanceof Response) return auth
   if ((auth as TokenRow).role !== 'owner') {

--- a/functions/api/_shared/ulid.ts
+++ b/functions/api/_shared/ulid.ts
@@ -1,4 +1,9 @@
 const ENCODING = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+const ULID_PATTERN = /^[0-9A-HJKMNP-TV-Z]{26}$/
+
+export function isUlid (value: unknown): value is string {
+  return typeof value === 'string' && ULID_PATTERN.test(value)
+}
 
 export function generateUlid (): string {
   const chars: string[] = new Array(26)

--- a/tests/integration/api/lists.spec.ts
+++ b/tests/integration/api/lists.spec.ts
@@ -210,6 +210,18 @@ describe('POST /api/lists/:id/join', () => {
     expect(res.status).toBe(401)
   })
 
+  it('returns 400 for non-ULID list ids', async () => {
+    for (const badId of ['', 'not-a-ulid', 'a'.repeat(26), '01JVKZ0000000000000000000', '01JVKZ000000000000000000000']) {
+      const req = new Request(`http://localhost/api/lists/${badId}/join`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: 'anything' })
+      })
+      const res = await handleJoin(db, req, badId)
+      expect(res.status).toBe(400)
+    }
+  })
+
   it('returns 401 when token belongs to a different list', async () => {
     const { authToken } = await provision('List A')
     const { id: otherId } = await provision('List B')
@@ -342,6 +354,14 @@ describe('GET /api/lists/:id?since=', () => {
       headers: { Authorization: `Bearer ${authToken}` }
     })
     const res = await handlePoll(db, req, id)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for non-ULID list ids', async () => {
+    const req = new Request('http://localhost/api/lists/garbage?since=0', {
+      headers: { Authorization: 'Bearer whatever' }
+    })
+    const res = await handlePoll(db, req, 'garbage')
     expect(res.status).toBe(400)
   })
 })


### PR DESCRIPTION
## Summary
- Route params were passed straight into D1 queries; empty or oversized list ids reached the database.
- Added an `isUlid` helper and a 400 guard at the top of every listId-scoped handler (poll, delete, join, upsert, mint, revoke).

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run test:integration` (added 400 cases for `handleJoin` and `handlePoll`)
- [x] `npm run build`

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)