### PR TITLE
fix(share-sheet): guard copy timer against post-unmount writes (#101)

### DIFF
--- a/src/components/ShareSheet.vue
+++ b/src/components/ShareSheet.vue
@@ -103,6 +103,7 @@ const { announce } = useLiveRegion()
 
 let copyTimer: ReturnType<typeof setTimeout> | null = null
 let provisionedListId: string | null = null
+let isMounted = true
 
 const isOwner = computed(() => sync.getMeta(props.list.id)?.role === 'owner')
 
@@ -214,11 +215,17 @@ async function onCopy () {
   if (!joinUrl.value) return
   try {
     await navigator.clipboard.writeText(joinUrl.value)
+    if (!isMounted) return
     copied.value = true
     announce('Link copied to clipboard')
     if (copyTimer) clearTimeout(copyTimer)
-    copyTimer = setTimeout(() => { copied.value = false }, 2000)
+    copyTimer = setTimeout(() => {
+      copyTimer = null
+      if (!isMounted) return
+      copied.value = false
+    }, 2000)
   } catch {
+    if (!isMounted) return
     announce('Could not copy link')
   }
 }
@@ -254,7 +261,11 @@ watch(() => props.open, async (isOpen) => {
 })
 
 onUnmounted(() => {
-  if (copyTimer) clearTimeout(copyTimer)
+  isMounted = false
+  if (copyTimer) {
+    clearTimeout(copyTimer)
+    copyTimer = null
+  }
 })
 </script>
 

--- a/tests/unit/components/ShareSheet.spec.ts
+++ b/tests/unit/components/ShareSheet.spec.ts
@@ -206,4 +206,25 @@ describe('ShareSheet', () => {
     await flushPromises()
     expect(true).toBe(true)
   })
+
+  it('does not schedule a reset timer when unmounted before clipboard resolves', async () => {
+    let resolveWrite: (v?: unknown) => void = () => {}
+    const writeText = vi.fn(() => new Promise(resolve => { resolveWrite = resolve }))
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+    vi.useFakeTimers()
+
+    const wrapper = mountSheet({ open: true })
+    await flushPromises()
+    await wrapper.findAll('button').find(b => b.text().includes('Copy link'))!.trigger('click')
+
+    wrapper.unmount()
+    resolveWrite()
+    await flushPromises()
+
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    vi.advanceTimersByTime(5000)
+    expect(setTimeoutSpy).not.toHaveBeenCalled()
+
+    vi.useRealTimers()
+  })
 })


### PR DESCRIPTION
## Summary
- `onUnmounted` already cleared `copyTimer`, but the timer is scheduled *after* an awaited `navigator.clipboard.writeText()` — so a sheet unmounted while the clipboard promise was in flight still scheduled a timer that later mutated destroyed refs.
- Track an `isMounted` flag, short-circuit `onCopy` and the timer callback when the sheet is gone, and null the handle after it fires.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test:unit` (added regression test using fake timers)
- [x] `npm run build`

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)