### PR TITLE
fix(sync/storage): preserve corrupted syncMeta on parse failure (#96)

### DIFF
--- a/src/sync/storage.ts
+++ b/src/sync/storage.ts
@@ -1,12 +1,32 @@
 import type { SyncMeta, SyncMetaMap } from './types'
 
 const KEY = 'syncMeta'
+const CORRUPTED_PREFIX = 'syncMeta.corrupted.'
 
 export function getSyncMetaMap (): SyncMetaMap {
+  const raw = localStorage.getItem(KEY)
+  if (raw === null) return {}
   try {
-    return JSON.parse(localStorage.getItem(KEY) ?? '{}') as SyncMetaMap
-  } catch {
+    const parsed = JSON.parse(raw) as unknown
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      backupCorrupted(raw, 'unexpected shape')
+      return {}
+    }
+    return parsed as SyncMetaMap
+  } catch (err) {
+    backupCorrupted(raw, err)
     return {}
+  }
+}
+
+function backupCorrupted (raw: string, reason: unknown): void {
+  const backupKey = `${CORRUPTED_PREFIX}${Date.now()}`
+  console.warn('[sync/storage] corrupted syncMeta — preserving to', backupKey, reason)
+  try {
+    localStorage.setItem(backupKey, raw)
+    localStorage.removeItem(KEY)
+  } catch {
+    // Quota or storage gone — caller will continue with an empty map regardless.
   }
 }
 

--- a/tests/unit/sync/storage.spec.ts
+++ b/tests/unit/sync/storage.spec.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { getSyncMetaMap, saveSyncMetaMap, getMeta, setMeta, removeMeta } from '@/sync/storage'
 
 const META = { authToken: 'tok', role: 'owner' as const, lastCursor: 1 }
 
 describe('sync/storage', () => {
-  beforeEach(() => localStorage.clear())
+  beforeEach(() => {
+    localStorage.clear()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => vi.restoreAllMocks())
 
   it('getSyncMetaMap returns {} when nothing stored', () => {
     expect(getSyncMetaMap()).toEqual({})
@@ -13,6 +17,24 @@ describe('sync/storage', () => {
   it('getSyncMetaMap returns {} when stored value is invalid JSON', () => {
     localStorage.setItem('syncMeta', 'not-json')
     expect(getSyncMetaMap()).toEqual({})
+  })
+
+  it('getSyncMetaMap backs up corrupted blob and warns', () => {
+    localStorage.setItem('syncMeta', '{not valid json')
+    expect(getSyncMetaMap()).toEqual({})
+    expect(console.warn).toHaveBeenCalled()
+    const backups = Object.keys(localStorage).filter(k => k.startsWith('syncMeta.corrupted.'))
+    expect(backups).toHaveLength(1)
+    expect(localStorage.getItem(backups[0])).toBe('{not valid json')
+    expect(localStorage.getItem('syncMeta')).toBeNull()
+  })
+
+  it('getSyncMetaMap backs up non-object JSON (array or null)', () => {
+    localStorage.setItem('syncMeta', '[]')
+    expect(getSyncMetaMap()).toEqual({})
+    expect(console.warn).toHaveBeenCalled()
+    const backups = Object.keys(localStorage).filter(k => k.startsWith('syncMeta.corrupted.'))
+    expect(backups).toHaveLength(1)
   })
 
   it('saveSyncMetaMap round-trips through getSyncMetaMap', () => {


### PR DESCRIPTION
## Summary
- `getSyncMetaMap` swallowed `JSON.parse` errors and returned `{}`, silently wiping a user's sync state.
- Move the corrupted blob to a timestamped backup key (`syncMeta.corrupted.<ts>`), `console.warn` for a diagnostic trail, and clear the live key so the next write starts clean.
- Also reject non-object payloads (array, null, primitive) the same way.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test:unit` (added corruption + non-object payload regression tests)
- [x] `npm run build`

Fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)