### PR TITLE
fix(sync/queue): narrow loadQueue catch-all and quarantine corruption (#100)

### DIFF
--- a/src/sync/queue.ts
+++ b/src/sync/queue.ts
@@ -7,24 +7,62 @@ import { cleanupListLocally } from './cleanup'
 import type { Op, UpsertItemOp } from './types'
 
 const QUEUE_KEY = 'pendingOps'
+const CORRUPTED_PREFIX = 'pendingOps.corrupted.'
 const MAX_BACKOFF_MS = 60_000
 
 let flushRunning = false
 let backoffMs = 1_000
 
 function loadQueue (): Op[] {
+  let raw: string | null
   try {
-    const raw = JSON.parse(localStorage.getItem(QUEUE_KEY) ?? '[]') as Array<Op & { opId?: string }>
-    let migrated = false
-    for (const op of raw) {
-      if (!op.opId) {
-        op.opId = crypto.randomUUID()
-        migrated = true
-      }
+    raw = localStorage.getItem(QUEUE_KEY)
+  } catch (err) {
+    console.warn('[sync/queue] localStorage unavailable for read', err)
+    return []
+  }
+  if (raw === null) return []
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    console.warn('[sync/queue] corrupted pendingOps — preserving and discarding', err)
+    quarantineCorrupted(raw)
+    return []
+  }
+  if (!Array.isArray(parsed)) {
+    console.warn('[sync/queue] pendingOps not an array — preserving and discarding')
+    quarantineCorrupted(raw)
+    return []
+  }
+
+  const ops = parsed as Array<Op & { opId?: string }>
+  let migrated = false
+  for (const op of ops) {
+    if (op && !op.opId) {
+      op.opId = crypto.randomUUID()
+      migrated = true
     }
-    if (migrated) saveQueue(raw as Op[])
-    return raw as Op[]
-  } catch { return [] }
+  }
+  if (migrated) {
+    try {
+      saveQueue(ops as Op[])
+    } catch (err) {
+      console.warn('[sync/queue] failed to persist migrated queue', err)
+    }
+  }
+  return ops as Op[]
+}
+
+function quarantineCorrupted (raw: string): void {
+  try {
+    localStorage.setItem(`${CORRUPTED_PREFIX}${Date.now()}`, raw)
+    localStorage.removeItem(QUEUE_KEY)
+  } catch {
+    // Quota or storage gone — drop the live key best-effort.
+    try { localStorage.removeItem(QUEUE_KEY) } catch { /* nothing more to do */ }
+  }
 }
 
 function saveQueue (q: Op[]): void {

--- a/tests/unit/sync/queue.spec.ts
+++ b/tests/unit/sync/queue.spec.ts
@@ -124,6 +124,26 @@ describe('flush — concurrent-tab race', () => {
     expect(typeof q[0].opId).toBe('string')
     expect((q[0].opId ?? '').length).toBeGreaterThan(0)
   })
+
+  it('quarantines and discards a corrupted pendingOps blob', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    localStorage.setItem('pendingOps', '{not json')
+    startDrainer()
+    expect(localStorage.getItem('pendingOps')).toBeNull()
+    const backups = Object.keys(localStorage).filter(k => k.startsWith('pendingOps.corrupted.'))
+    expect(backups).toHaveLength(1)
+    expect(localStorage.getItem(backups[0])).toBe('{not json')
+    expect(console.warn).toHaveBeenCalled()
+  })
+
+  it('quarantines a non-array pendingOps blob', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    localStorage.setItem('pendingOps', JSON.stringify({ ops: [] }))
+    startDrainer()
+    expect(localStorage.getItem('pendingOps')).toBeNull()
+    const backups = Object.keys(localStorage).filter(k => k.startsWith('pendingOps.corrupted.'))
+    expect(backups).toHaveLength(1)
+  })
 })
 
 describe('flush — success path', () => {


### PR DESCRIPTION
## Summary
- One blanket `try/catch` around `loadQueue` returned `[]` on every failure mode — masking corruption, `SecurityError` from disabled storage, and quota exhaustion during the migration write.
- Split read / parse / shape-check / migration-save into separate guards, log the error class on each, and preserve any corrupted blob under `pendingOps.corrupted.<ts>` before clearing the live key.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test:unit` (added regression tests for invalid JSON and non-array payloads)
- [x] `npm run build`

Fixes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)