### PR TITLE
fix(lists): surface persist failures via toast (#98)

### DIFF
--- a/src/stores/lists.ts
+++ b/src/stores/lists.ts
@@ -4,6 +4,7 @@ import type List from '@/classes/List'
 import type Item from '@/classes/Item'
 import { getMeta } from '@/sync/storage'
 import { enqueue } from '@/sync/queue'
+import { useToastStore } from '@/stores/toast'
 
 function sortItems (list: List) {
   list.i.sort((a, b) => a.n.localeCompare(b.n, undefined, { sensitivity: 'base' }))
@@ -11,13 +12,25 @@ function sortItems (list: List) {
 
 export const useListsStore = defineStore('lists', () => {
   const lists = ref<List[]>([])
+  let lastPersistFailed = false
 
   function getListFromId (id: string) {
     return lists.value.find(l => l.id === id)
   }
 
-  function persist () {
-    localStorage.setItem('lists', JSON.stringify(lists.value))
+  function persist (): boolean {
+    try {
+      localStorage.setItem('lists', JSON.stringify(lists.value))
+      lastPersistFailed = false
+      return true
+    } catch (err) {
+      console.warn('[lists] failed to persist', err)
+      if (!lastPersistFailed) {
+        useToastStore().add('Could not save changes — your device may be out of storage.', 'error')
+        lastPersistFailed = true
+      }
+      return false
+    }
   }
 
   function init () {

--- a/tests/unit/stores/lists.spec.ts
+++ b/tests/unit/stores/lists.spec.ts
@@ -1,6 +1,7 @@
 import { setActivePinia, createPinia } from 'pinia'
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { useListsStore } from '@/stores/lists'
+import { useToastStore } from '@/stores/toast'
 import List from '@/classes/List'
 import Item from '@/classes/Item'
 
@@ -76,6 +77,31 @@ describe('lists store', () => {
   it('getListFromId returns undefined for unknown id', () => {
     const store = useListsStore()
     expect(store.getListFromId('unknown')).toBeUndefined()
+  })
+
+  describe('persist error handling', () => {
+    afterEach(() => vi.restoreAllMocks())
+
+    it('emits an error toast and keeps in-memory state when persist throws', () => {
+      const store = useListsStore()
+      const list = new List('Quota', [])
+      store.createList(list)
+      const toast = useToastStore()
+
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new DOMException('QuotaExceededError', 'QuotaExceededError')
+      })
+
+      store.addItem(list.id, new Item('Milk', '1'))
+
+      expect(store.lists[0].i).toHaveLength(1)
+      expect(toast.toasts).toHaveLength(1)
+      expect(toast.toasts[0].type).toBe('error')
+
+      store.addItem(list.id, new Item('Eggs', '1'))
+      expect(toast.toasts).toHaveLength(1)
+    })
   })
 
   describe('replaceList', () => {


### PR DESCRIPTION
## Summary
- `writeList` (and every other store mutator) called `persist()` with no error handling, so a quota or serialization failure left in-memory state diverged from disk with no signal to the UI.
- Wrap `persist()` in `try/catch`, log the failure, and fire a single error toast per failure streak. In-memory state is preserved so the next persist can retry on its own.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test:unit` (added quota-failure test that asserts toast + retained state)
- [x] `npm run build`

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)