### PR TITLE
fix(validate): reject empty/whitespace-only item names

### DIFF
--- a/functions/api/_shared/validate.ts
+++ b/functions/api/_shared/validate.ts
@@ -16,7 +16,7 @@ export function validateItem (raw: unknown): ItemRow | null {
   const r = raw as Record<string, unknown>
 
   if (typeof r.id !== 'string' || r.id.length === 0 || r.id.length > LIMITS.itemIdMax) return null
-  if (typeof r.n !== 'string' || r.n.length > LIMITS.itemNameMax) return null
+  if (typeof r.n !== 'string' || r.n.trim().length === 0 || r.n.length > LIMITS.itemNameMax) return null
   if (typeof r.u !== 'number' || !Number.isFinite(r.u) || r.u < 0 || r.u > MAX_TIMESTAMP) return null
 
   const q = r.q === undefined ? '' : r.q

--- a/tests/integration/api/lists.spec.ts
+++ b/tests/integration/api/lists.spec.ts
@@ -133,6 +133,8 @@ describe('POST /api/lists', () => {
       { id: 'abc12345', n: 'Milk', q: '1', c: 0, u: '1000', d: 0 }, // u non-number
       { id: 'abc12345', n: 'Milk', q: '1', c: 0, u: 1000, d: 2 }, // d out of range
       { id: '', n: 'Milk', q: '1', c: 0, u: 1000, d: 0 }, // id empty
+      { id: 'abc12345', n: '', q: '1', c: 0, u: 1000, d: 0 }, // n empty
+      { id: 'abc12345', n: '   ', q: '1', c: 0, u: 1000, d: 0 }, // n whitespace-only
       { n: 'Milk', q: '1', c: 0, u: 1000, d: 0 } // id missing
     ]
     for (const item of cases) {


### PR DESCRIPTION
## Summary
- `validateItem` rejected empty names because only the upper bound was checked
- Add `r.n.trim().length > 0` to the validator
- Add integration test cases for empty and whitespace-only `n`

Closes #113

## Test plan
- [x] `npm run test:unit`
- [x] `npm run test:integration`
- [x] `npm run lint`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)