### PR TITLE
fix(toast): track dismissal timers and cancel on manual dismiss/reset

### DIFF
--- a/src/stores/toast.ts
+++ b/src/stores/toast.ts
@@ -10,19 +10,31 @@ interface Toast {
 
 export const useToastStore = defineStore('toast', () => {
   const toasts = ref<Toast[]>([])
+  const timers = new Map<number, ReturnType<typeof setTimeout>>()
   let nextId = 0
 
   function add (message: string, type: Toast['type'] = 'info'): void {
     const id = nextId++
     toasts.value.push({ id, message, type })
     useLiveRegion().announce(message)
-    setTimeout(() => dismiss(id), 5000)
+    timers.set(id, setTimeout(() => dismiss(id), 5000))
   }
 
   function dismiss (id: number): void {
+    const timer = timers.get(id)
+    if (timer !== undefined) {
+      clearTimeout(timer)
+      timers.delete(id)
+    }
     const idx = toasts.value.findIndex(t => t.id === id)
     if (idx !== -1) toasts.value.splice(idx, 1)
   }
 
-  return { toasts, add, dismiss }
+  function reset (): void {
+    for (const timer of timers.values()) clearTimeout(timer)
+    timers.clear()
+    toasts.value = []
+  }
+
+  return { toasts, add, dismiss, reset }
 })

--- a/tests/unit/stores/toast.spec.ts
+++ b/tests/unit/stores/toast.spec.ts
@@ -50,6 +50,27 @@ describe('useToastStore', () => {
     expect(store.toasts).toHaveLength(0)
   })
 
+  it('manual dismiss cancels the auto-dismiss timer (no post-unmount mutation)', () => {
+    const store = useToastStore()
+    store.add('One')
+    const id = store.toasts[0].id
+    store.dismiss(id)
+    store.add('Two')
+    vi.advanceTimersByTime(5000)
+    expect(store.toasts).toHaveLength(0)
+  })
+
+  it('reset clears all toasts and pending timers', () => {
+    const store = useToastStore()
+    store.add('One')
+    store.add('Two')
+    expect(store.toasts).toHaveLength(2)
+    store.reset()
+    expect(store.toasts).toHaveLength(0)
+    vi.advanceTimersByTime(10000)
+    expect(store.toasts).toHaveLength(0)
+  })
+
   it('multiple toasts each auto-dismiss independently', () => {
     const store = useToastStore()
     store.add('First')


### PR DESCRIPTION
## Summary
- Track each toast's `setTimeout` id in a `Map<id, timer>`
- Clear the timer on manual `dismiss(id)` so it cannot fire later
- Add `reset()` that clears all toasts and pending timers

Closes #107

## Test plan
- [x] `npm run test:unit`
- [x] `npm run test:integration`
- [x] `npm run lint`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)