### PR TITLE
refactor(ListItem): emit typed input element instead of raw Event

### DIFF
--- a/src/components/ListItem.vue
+++ b/src/components/ListItem.vue
@@ -15,7 +15,7 @@
                :id="`item-qty-${item.id}`"
                :value="item.q"
                class="item__quantity__input"
-               @change="$emit('update:quantity', $event)"/>
+               @change="onQuantityChange"/>
       </div>
       <label :for="`item-name-${item.id}`" class="sr-only">{{ item.n }} Name</label>
       <input type="text"
@@ -23,7 +23,7 @@
              :value="item.n"
              :ref="nameRef"
              class="item__name"
-             @change="$emit('update:name', $event)"/>
+             @change="onNameChange"/>
       <button @click="$emit('delete')"
               :aria-label="`Remove ${item.n} from this list`"
               class="item__icon--delete">
@@ -42,10 +42,18 @@ defineProps<{
   nameRef: (el: unknown) => void
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   (e: 'toggle'): void
   (e: 'delete'): void
-  (e: 'update:name', event: Event): void
-  (e: 'update:quantity', event: Event): void
+  (e: 'update:name', input: HTMLInputElement): void
+  (e: 'update:quantity', input: HTMLInputElement): void
 }>()
+
+function onNameChange (event: Event): void {
+  emit('update:name', event.target as HTMLInputElement)
+}
+
+function onQuantityChange (event: Event): void {
+  emit('update:quantity', event.target as HTMLInputElement)
+}
 </script>

--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -129,8 +129,7 @@ function addItemToList (): void {
   itemName.value!.focus()
 }
 
-function modifyItemQuantity (event: Event, id: string): void {
-  const input = event.target as HTMLInputElement
+function modifyItemQuantity (input: HTMLInputElement, id: string): void {
   const item = list.value!.i.find(i => i.id === id)
   if (!item) return
   const trimmed = input.value.trim()
@@ -141,8 +140,7 @@ function modifyItemQuantity (event: Event, id: string): void {
   }
 }
 
-function modifyItemName (event: Event, id: string): void {
-  const input = event.target as HTMLInputElement
+function modifyItemName (input: HTMLInputElement, id: string): void {
   if (input.value) {
     listsStore.updateItem(listId.value, id, { n: input.value })
   }

--- a/tests/unit/components/ListItem.spec.ts
+++ b/tests/unit/components/ListItem.spec.ts
@@ -30,16 +30,24 @@ describe('ListItem.vue', () => {
     expect(wrapper.emitted('delete')).toHaveLength(1)
   })
 
-  it('emits update:name on the name input change event', async () => {
+  it('emits update:name with the input element on change', async () => {
     const wrapper = mountItem()
     await wrapper.find('.item__name').setValue('Oranges')
-    expect(wrapper.emitted('update:name')).toBeTruthy()
+    const emitted = wrapper.emitted('update:name') as unknown[][]
+    expect(emitted).toHaveLength(1)
+    const [input] = emitted[0] as [HTMLInputElement]
+    expect(input).toBeInstanceOf(HTMLInputElement)
+    expect(input.value).toBe('Oranges')
   })
 
-  it('emits update:quantity on the quantity input change event', async () => {
+  it('emits update:quantity with the input element on change', async () => {
     const wrapper = mountItem()
     await wrapper.find('.item__quantity__input').setValue('5')
-    expect(wrapper.emitted('update:quantity')).toBeTruthy()
+    const emitted = wrapper.emitted('update:quantity') as unknown[][]
+    expect(emitted).toHaveLength(1)
+    const [input] = emitted[0] as [HTMLInputElement]
+    expect(input).toBeInstanceOf(HTMLInputElement)
+    expect(input.value).toBe('5')
   })
 
   it('applies the checkbox-icon--checked class when checked is true', () => {


### PR DESCRIPTION
## Summary
- `ListItem` now exposes `update:name` / `update:quantity` as `HTMLInputElement` rather than raw `Event`
- Local script handlers do the one cast at the boundary; `List.vue` consumers receive a typed input directly
- Tests assert the emitted payload is an `HTMLInputElement` with the expected value

Closes #106

## Test plan
- [x] `npm run test:unit`
- [x] `npm run test:integration`
- [x] `npm run lint`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)