### PR TITLE
refactor(handlers): drop redundant TokenRow cast after authenticate guard

### DIFF
--- a/functions/api/_shared/handlers.ts
+++ b/functions/api/_shared/handlers.ts
@@ -187,7 +187,7 @@ export async function handleMintToken (
   if (!isUlid(listId)) return invalidListId()
   const auth = await authenticate(db, request, listId)
   if (auth instanceof Response) return auth
-  if ((auth as TokenRow).role !== 'owner') {
+  if (auth.role !== 'owner') {
     return Response.json({ error: 'Forbidden' }, { status: 403 })
   }
 
@@ -210,7 +210,7 @@ export async function handleRevokeToken (
   if (!isUlid(listId)) return invalidListId()
   const auth = await authenticate(db, request, listId)
   if (auth instanceof Response) return auth
-  if ((auth as TokenRow).role !== 'owner') {
+  if (auth.role !== 'owner') {
     return Response.json({ error: 'Forbidden' }, { status: 403 })
   }
 
@@ -229,7 +229,7 @@ export async function handleDeleteList (
   if (!isUlid(listId)) return invalidListId()
   const auth = await authenticate(db, request, listId)
   if (auth instanceof Response) return auth
-  if ((auth as TokenRow).role !== 'owner') {
+  if (auth.role !== 'owner') {
     return Response.json({ error: 'Forbidden' }, { status: 403 })
   }
 


### PR DESCRIPTION
## Summary
- `authenticate()` already returns `TokenRow | Response`; TS narrows to `TokenRow` after the `instanceof Response` guard
- Drop three redundant `(auth as TokenRow).role` casts

Closes #104

## Test plan
- [x] `npm run type-check`
- [x] `npm run test:unit`
- [x] `npm run test:integration`
- [x] `npm run lint`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)