### PR TITLE
refactor(sync): unify role contract via shared/roles + provision response

### DIFF
--- a/functions/api/_shared/handlers.ts
+++ b/functions/api/_shared/handlers.ts
@@ -2,6 +2,7 @@ import type { ItemRow, ListRow, TokenRow } from './types'
 import { generateUlid, generateToken, isUlid } from './ulid'
 import { authenticate } from './auth'
 import { hashToken } from '../../../shared/crypto'
+import { ROLES } from '../../../shared/roles'
 import { LIMITS, readJsonBody, validateItem } from './validate'
 
 function invalidListId (): Response {
@@ -81,7 +82,7 @@ export async function handleProvision (db: D1Database, request: Request): Promis
     ).bind(listId, name, now),
     db.prepare(
       'INSERT INTO list_tokens (token_hash, list_id, role, created_at) VALUES (?, ?, ?, ?)'
-    ).bind(tokenHash, listId, 'owner', now),
+    ).bind(tokenHash, listId, ROLES.owner, now),
     ...items.map((item) =>
       db.prepare(
         'INSERT INTO items (list_id, id, n, q, c, u, d) VALUES (?, ?, ?, ?, ?, ?, ?)'
@@ -89,7 +90,7 @@ export async function handleProvision (db: D1Database, request: Request): Promis
     )
   ])
 
-  return Response.json({ id: listId, authToken })
+  return Response.json({ id: listId, authToken, role: ROLES.owner })
 }
 
 export async function handlePoll (
@@ -171,7 +172,7 @@ export async function handleJoin (
 
   return Response.json({
     listId: list.id,
-    role: 'editor',
+    role: ROLES.editor,
     name: list.name,
     version: list.version,
     cursor,

--- a/functions/api/_shared/types.ts
+++ b/functions/api/_shared/types.ts
@@ -1,3 +1,5 @@
+import type { Role } from '../../../shared/roles'
+
 export interface Env {
   DB: D1Database
 }
@@ -20,6 +22,6 @@ export interface ItemRow {
 
 export interface TokenRow {
   list_id: string
-  role: 'owner' | 'editor'
+  role: Role
   revoked_at: number | null
 }

--- a/shared/roles.ts
+++ b/shared/roles.ts
@@ -1,0 +1,6 @@
+export type Role = 'owner' | 'editor'
+
+export const ROLES = {
+  owner: 'owner',
+  editor: 'editor'
+} as const satisfies Record<Role, Role>

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -22,11 +22,11 @@ export async function provision (
   const result = await provisionList(list.n, items)
   if (!result.ok) return null
 
-  const { id: newListId, authToken } = result.data
+  const { id: newListId, authToken, role } = result.data
   const lastCursor = items.reduce((m, i) => Math.max(m, i.u), 0)
 
   store.updateListId(list.id, newListId)
-  setMeta(newListId, { authToken, role: 'owner', lastCursor })
+  setMeta(newListId, { authToken, role, lastCursor })
   startPoller(newListId)
 
   const joinUrl = `${window.location.origin}/#join=${newListId}.${authToken}`

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -1,6 +1,10 @@
+import type { Role } from '../../shared/roles'
+
+export type { Role }
+
 export interface SyncMeta {
   authToken: string
-  role: 'owner' | 'editor'
+  role: Role
   lastCursor: number
   shareToken?: string
 }
@@ -26,11 +30,12 @@ export interface ItemPayload {
 export interface ProvisionResponse {
   id: string
   authToken: string
+  role: Role
 }
 
 export interface JoinResponse {
   listId: string
-  role: 'owner' | 'editor'
+  role: Role
   name: string
   version: number
   cursor: number

--- a/tests/integration/api/lists.spec.ts
+++ b/tests/integration/api/lists.spec.ts
@@ -45,7 +45,7 @@ beforeEach(async () => {
 // ---------------------------------------------------------------------------
 
 describe('POST /api/lists', () => {
-  it('provisions a list and returns id + authToken', async () => {
+  it('provisions a list and returns id + authToken + role', async () => {
     const req = new Request('http://localhost/api/lists', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -53,10 +53,11 @@ describe('POST /api/lists', () => {
     })
     const res = await handleProvision(db, req)
     expect(res.status).toBe(200)
-    const body = await res.json() as { id: string; authToken: string }
+    const body = await res.json() as { id: string; authToken: string; role: string }
     expect(body.id).toMatch(/^[0-9A-Z]{26}$/) // ULID
     expect(body.authToken).toBeTruthy()
     expect(body.authToken.length).toBeGreaterThan(30)
+    expect(body.role).toBe('owner')
   })
 
   it('provisions a list with items', async () => {

--- a/tests/unit/sync/provision-join.spec.ts
+++ b/tests/unit/sync/provision-join.spec.ts
@@ -34,7 +34,7 @@ describe('sync/index — provision', () => {
   })
 
   it('renames list id, saves meta, starts poller, and returns joinUrl + listId', async () => {
-    mProvisionList.mockResolvedValue({ ok: true, data: { id: 'srv1', authToken: 'tok1' } })
+    mProvisionList.mockResolvedValue({ ok: true, data: { id: 'srv1', authToken: 'tok1', role: 'owner' as const } })
     const store = useListsStore()
     store.$patch({ lists: [{ id: 'loc1', n: 'Groceries', i: [] }] })
 
@@ -48,7 +48,7 @@ describe('sync/index — provision', () => {
   })
 
   it('sends only non-deleted items to provisionList', async () => {
-    mProvisionList.mockResolvedValue({ ok: true, data: { id: 'srv2', authToken: 't2' } })
+    mProvisionList.mockResolvedValue({ ok: true, data: { id: 'srv2', authToken: 't2', role: 'owner' as const } })
     const list = {
       id: 'loc2',
       n: 'List',
@@ -65,7 +65,7 @@ describe('sync/index — provision', () => {
   })
 
   it('sets lastCursor to max(item.u) of provisioned non-deleted items', async () => {
-    mProvisionList.mockResolvedValue({ ok: true, data: { id: 'srv3', authToken: 't3' } })
+    mProvisionList.mockResolvedValue({ ok: true, data: { id: 'srv3', authToken: 't3', role: 'owner' as const } })
     const list = {
       id: 'loc3',
       n: 'List',


### PR DESCRIPTION
## Summary
- New `shared/roles.ts` exporting `Role` and `ROLES`
- Server's `handleProvision` now returns `role: 'owner'` so provision and join paths consume the role uniformly from the response
- Client `provision()` no longer hardcodes `'owner'` — pulls from `result.data.role`
- `TokenRow`, `SyncMeta`, `ProvisionResponse`, `JoinResponse` all reference the shared `Role` type for compile-time alignment
- Existing integration test asserts `role: 'owner'` in the provision response

Closes #105

## Test plan
- [x] `npm run type-check`
- [x] `npm run test:unit`
- [x] `npm run test:integration`
- [x] `npm run lint`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)