### PR TITLE
chore(vite): tighten coverage exclude to type-only declarations

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -37,7 +37,9 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html'],
       include: ['src/**', 'shared/**'],
-      exclude: ['src/main.ts', 'src/router/**', 'src/**/*.d.ts', 'src/assets/**', 'src/sync/types.ts'],
+      // Excludes are limited to type-only declarations and non-runtime assets.
+      // Do NOT add runtime modules here without also gating them on a test.
+      exclude: ['src/main.ts', 'src/router/**', '**/*.d.ts', 'src/assets/**', 'src/**/types.ts', 'shared/**/types.ts'],
       thresholds: {
         lines: 80,
         functions: 80,


### PR DESCRIPTION
## Summary
- Replaced single-file exclude `src/sync/types.ts` with glob `src/**/types.ts` (and `shared/**/types.ts`) so every pure-type module is excluded uniformly
- Generalized `.d.ts` exclude with `**/*.d.ts`
- Added a comment forbidding runtime modules from being slipped into the exclude list

Closes #111

## Test plan
- [x] `npm run test:coverage` — all thresholds pass
- [x] `npm run test:unit`
- [x] `npm run test:integration`
- [x] `npm run lint`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)