### PR TITLE
fix(App): retry join on transient network errors with bounded backoff

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -30,6 +30,18 @@ const loaded = ref(false)
 const { message: liveMessage, announce } = useLiveRegion()
 const { init: initTheme, cleanup: cleanupTheme } = useTheme()
 
+const JOIN_RETRY_DELAYS_MS = [1000, 2000, 4000]
+
+async function tryJoinWithRetry (listId: string, token: string): Promise<sync.JoinResult> {
+  let result = await sync.join(listId, token)
+  for (const delay of JOIN_RETRY_DELAYS_MS) {
+    if (result.ok || result.reason !== 'network') return result
+    await new Promise(resolve => setTimeout(resolve, delay))
+    result = await sync.join(listId, token)
+  }
+  return result
+}
+
 async function handleJoinFragment () {
   const m = /^#join=([^.]+)\.(.+)$/.exec(window.location.hash)
   if (!m) return
@@ -42,9 +54,11 @@ async function handleJoinFragment () {
     return
   }
 
-  const ok = await sync.join(listId, token)
-  if (ok) {
+  const result = await tryJoinWithRetry(listId, token)
+  if (result.ok) {
     router.replace({ name: 'List', params: { id: listId } })
+  } else if (result.reason === 'network') {
+    announce('Could not join list — network unavailable, please try the link again when online.')
   } else {
     announce('Could not join list — link may be invalid or revoked.')
   }

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -33,9 +33,13 @@ export async function provision (
   return { joinUrl, listId: newListId }
 }
 
-export async function join (listId: string, token: string): Promise<boolean> {
+export type JoinResult = { ok: true } | { ok: false; reason: 'network' | 'invalid' }
+
+export async function join (listId: string, token: string): Promise<JoinResult> {
   const result = await joinList(listId, token)
-  if (!result.ok) return false
+  if (!result.ok) {
+    return { ok: false, reason: result.error.kind === 'network' ? 'network' : 'invalid' }
+  }
 
   applyJoinPayload(result.data)
   setMeta(listId, {
@@ -44,7 +48,7 @@ export async function join (listId: string, token: string): Promise<boolean> {
     lastCursor: result.data.cursor
   })
   startPoller(listId)
-  return true
+  return { ok: true }
 }
 
 export function startPolling (): void {

--- a/tests/unit/AppJoin.spec.ts
+++ b/tests/unit/AppJoin.spec.ts
@@ -9,7 +9,7 @@ import * as sync from '@/sync'
 vi.mock('@/sync', () => ({
   startPolling: vi.fn(),
   getMeta: vi.fn(() => null),
-  join: vi.fn(() => Promise.resolve(false)),
+  join: vi.fn(() => Promise.resolve({ ok: false, reason: 'invalid' as const })),
   getSyncMetaMap: vi.fn(() => ({})),
   saveSyncMetaMap: vi.fn()
 }))
@@ -55,7 +55,7 @@ describe('App.vue — handleJoinFragment', () => {
   })
 
   it('calls join and navigates to the list on a valid fragment', async () => {
-    vi.mocked(sync.join).mockResolvedValue(true)
+    vi.mocked(sync.join).mockResolvedValue({ ok: true })
     window.location.hash = '#join=listid123.tokenxyz'
     const router = makeRouter()
     await mountApp(router)
@@ -74,11 +74,77 @@ describe('App.vue — handleJoinFragment', () => {
   })
 
   it('stays on Lists and does not navigate when join fails', async () => {
-    vi.mocked(sync.join).mockResolvedValue(false)
+    vi.mocked(sync.join).mockResolvedValue({ ok: false, reason: 'invalid' })
     window.location.hash = '#join=listid123.tokenxyz'
     const router = makeRouter()
     await mountApp(router)
     expect(sync.join).toHaveBeenCalled()
     expect(router.currentRoute.value.name).toBe('Lists')
+  })
+
+  it('retries on network errors with backoff and succeeds when the network recovers', async () => {
+    vi.useFakeTimers()
+    vi.mocked(sync.join)
+      .mockResolvedValueOnce({ ok: false, reason: 'network' })
+      .mockResolvedValueOnce({ ok: false, reason: 'network' })
+      .mockResolvedValueOnce({ ok: true })
+    window.location.hash = '#join=listid123.tokenxyz'
+    const router = makeRouter()
+    await router.push('/')
+    const wrapper = mount(App, {
+      global: {
+        plugins: [createPinia(), router],
+        stubs: { FontAwesomeIcon: { template: '<span/>' } }
+      }
+    })
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(1000)
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(2000)
+    await flushPromises()
+    expect(sync.join).toHaveBeenCalledTimes(3)
+    expect(router.currentRoute.value.name).toBe('List')
+    wrapper.unmount()
+    vi.useRealTimers()
+  })
+
+  it('gives up after exhausting network retries', async () => {
+    vi.useFakeTimers()
+    vi.mocked(sync.join).mockResolvedValue({ ok: false, reason: 'network' })
+    window.location.hash = '#join=listid123.tokenxyz'
+    const router = makeRouter()
+    await router.push('/')
+    const wrapper = mount(App, {
+      global: {
+        plugins: [createPinia(), router],
+        stubs: { FontAwesomeIcon: { template: '<span/>' } }
+      }
+    })
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(7000)
+    await flushPromises()
+    expect(sync.join).toHaveBeenCalledTimes(4)
+    expect(router.currentRoute.value.name).toBe('Lists')
+    wrapper.unmount()
+    vi.useRealTimers()
+  })
+
+  it('does not retry on invalid-token errors', async () => {
+    vi.useFakeTimers()
+    vi.mocked(sync.join).mockResolvedValue({ ok: false, reason: 'invalid' })
+    window.location.hash = '#join=listid123.tokenxyz'
+    const router = makeRouter()
+    await router.push('/')
+    const wrapper = mount(App, {
+      global: {
+        plugins: [createPinia(), router],
+        stubs: { FontAwesomeIcon: { template: '<span/>' } }
+      }
+    })
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(10000)
+    expect(sync.join).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+    vi.useRealTimers()
   })
 })

--- a/tests/unit/sync/provision-join.spec.ts
+++ b/tests/unit/sync/provision-join.spec.ts
@@ -88,17 +88,23 @@ describe('sync/index — join', () => {
     vi.resetAllMocks()
   })
 
-  it('returns false when joinList fails', async () => {
+  it('returns reason: invalid on auth/server errors', async () => {
     mJoinList.mockResolvedValue({ ok: false, error: { kind: 'unauthorized' } })
-    expect(await join('list1', 'bad')).toBe(false)
+    expect(await join('list1', 'bad')).toEqual({ ok: false, reason: 'invalid' })
     expect(mStartPoller).not.toHaveBeenCalled()
   })
 
-  it('applies payload, saves meta, starts poller, and returns true', async () => {
+  it('returns reason: network on network errors so callers can retry', async () => {
+    mJoinList.mockResolvedValue({ ok: false, error: { kind: 'network' } })
+    expect(await join('list1', 'tok')).toEqual({ ok: false, reason: 'network' })
+    expect(mStartPoller).not.toHaveBeenCalled()
+  })
+
+  it('applies payload, saves meta, starts poller, and returns ok: true', async () => {
     const data = { listId: 'list2', role: 'editor' as const, name: 'Shared', version: 1, cursor: 1700, items: [] }
     mJoinList.mockResolvedValue({ ok: true, data })
 
-    expect(await join('list2', 'tok2')).toBe(true)
+    expect(await join('list2', 'tok2')).toEqual({ ok: true })
     expect(mApplyJoinPayload).toHaveBeenCalledWith(data)
     expect(getMeta('list2')).toEqual({ authToken: 'tok2', role: 'editor', lastCursor: 1700 })
     expect(mStartPoller).toHaveBeenCalledWith('list2')


### PR DESCRIPTION
## Summary
- `sync.join()` now returns a discriminated `JoinResult` (`{ ok: true } | { ok: false; reason: 'network' | 'invalid' }`)
- `App.vue#handleJoinFragment` retries on `network` failures up to 3 times (1s, 2s, 4s backoff), then announces a clearer error message
- Invalid/revoked tokens fail fast with the existing user-facing message
- Unit tests cover success on first try, retry-then-success, retry-then-give-up, and no-retry-on-invalid

Closes #112

## Test plan
- [x] `npm run type-check`
- [x] `npm run test:unit`
- [x] `npm run test:integration`
- [x] `npm run lint`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)