### PR TITLE
fix(sync): enqueue items added or modified during provision

### DIFF
--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -4,7 +4,7 @@ import { provisionList, joinList, mintToken, revokeToken, deleteListRequest } fr
 import { applyJoinPayload } from './reconcile'
 import { getMeta, setMeta, getSyncMetaMap, saveSyncMetaMap } from './storage'
 import { startPoller, stopPoller } from './poll'
-import { startDrainer } from './queue'
+import { startDrainer, enqueue } from './queue'
 import { cleanupListLocally } from './cleanup'
 
 export { getMeta, getSyncMetaMap, saveSyncMetaMap } from './storage'
@@ -19,6 +19,9 @@ export async function provision (
 ): Promise<{ joinUrl: string; listId: string } | null> {
   const store = useListsStore()
   const items = list.i.filter(i => !i.d)
+  // Snapshot id→u for the items sent in the provision body so we can detect
+  // items added or modified while the POST was in flight.
+  const sentSnapshot = new Map(items.map(i => [i.id, i.u]))
   const result = await provisionList(list.n, items)
   if (!result.ok) return null
 
@@ -27,6 +30,23 @@ export async function provision (
 
   store.updateListId(list.id, newListId)
   setMeta(newListId, { authToken, role, lastCursor })
+
+  // Items added or modified between the provision call and its response
+  // could not be enqueued at the time (no meta yet) and were not in the
+  // provision body. Enqueue them now so they reach the server.
+  const currentList = store.getListFromId(newListId)
+  if (currentList) {
+    for (const it of currentList.i) {
+      if (sentSnapshot.get(it.id) !== it.u) {
+        enqueue({
+          kind: 'upsertItem',
+          listId: newListId,
+          item: { id: it.id, n: it.n, q: it.q, c: it.c, u: it.u, d: it.d }
+        })
+      }
+    }
+  }
+
   startPoller(newListId)
 
   const joinUrl = `${window.location.origin}/#join=${newListId}.${authToken}`

--- a/tests/unit/sync/provision-join.spec.ts
+++ b/tests/unit/sync/provision-join.spec.ts
@@ -1,21 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { provision, join } from '@/sync'
-import { provisionList, joinList } from '@/sync/transport'
+import { provisionList, joinList, upsertItem } from '@/sync/transport'
 import { startPoller } from '@/sync/poll'
 import { applyJoinPayload } from '@/sync/reconcile'
 import { getMeta } from '@/sync/storage'
+import { _resetForTest as resetQueueForTest } from '@/sync/queue'
 import { useListsStore } from '@/stores/lists'
+import Item from '@/classes/Item'
 
 vi.mock('@/sync/transport', () => ({
   provisionList: vi.fn(),
-  joinList: vi.fn()
+  joinList: vi.fn(),
+  upsertItem: vi.fn().mockResolvedValue({ ok: false, error: { kind: 'network' as const } })
 }))
 vi.mock('@/sync/poll', () => ({ startPoller: vi.fn() }))
 vi.mock('@/sync/reconcile', () => ({ applyJoinPayload: vi.fn() }))
 
 const mProvisionList = vi.mocked(provisionList)
 const mJoinList = vi.mocked(joinList)
+const mUpsertItem = vi.mocked(upsertItem)
 const mStartPoller = vi.mocked(startPoller)
 const mApplyJoinPayload = vi.mocked(applyJoinPayload)
 
@@ -24,6 +28,11 @@ describe('sync/index — provision', () => {
     localStorage.clear()
     setActivePinia(createPinia())
     vi.resetAllMocks()
+    resetQueueForTest()
+    // Default: any enqueued ops the drainer picks up after provision return a
+    // network error so the loop backs off without spamming console. Tests
+    // assert on the queue contents before the drainer can drain it.
+    mUpsertItem.mockResolvedValue({ ok: false, error: { kind: 'network' as const } })
   })
 
   it('returns null when provisionList fails', async () => {
@@ -78,6 +87,62 @@ describe('sync/index — provision', () => {
     useListsStore().$patch({ lists: [list] })
     await provision(list)
     expect(getMeta('srv3')).toEqual({ authToken: 't3', role: 'owner', lastCursor: 250 })
+  })
+
+  // Items added while a provision POST is in flight are not in the body
+  // (snapshot taken pre-await) and cannot be enqueued at the time (no meta
+  // yet). The provision flow must catch them up after setMeta. See #139.
+  it('enqueues items added while provisionList is in flight', async () => {
+    let resolveProvision!: (v: { ok: true; data: { id: string; authToken: string; role: 'owner' } }) => void
+    mProvisionList.mockReturnValue(new Promise(resolve => { resolveProvision = resolve }))
+
+    const store = useListsStore()
+    const initialItem = { id: 'i1', n: 'Bread', q: '1', c: 0, u: 1, d: 0 }
+    store.$patch({ lists: [{ id: 'loc-race', n: 'List', i: [initialItem] }] })
+
+    const provisionPromise = provision({ id: 'loc-race', n: 'List', i: [initialItem] })
+
+    const lateItem = new Item('Milk', '2')
+    store.addItem('loc-race', lateItem)
+
+    resolveProvision({ ok: true, data: { id: 'srv-race', authToken: 'tok-race', role: 'owner' } })
+    await provisionPromise
+
+    const queue = JSON.parse(localStorage.getItem('pendingOps') ?? '[]') as Array<{ item: { id: string }; listId: string }>
+    expect(queue.some(op => op.item.id === lateItem.id && op.listId === 'srv-race')).toBe(true)
+  })
+
+  // Items modified mid-flight (e.g. the user edits a quantity while
+  // provision is pending) also need to be caught up — the server has the
+  // pre-edit version from the provision body.
+  it('enqueues items modified while provisionList is in flight', async () => {
+    let resolveProvision!: (v: { ok: true; data: { id: string; authToken: string; role: 'owner' } }) => void
+    mProvisionList.mockReturnValue(new Promise(resolve => { resolveProvision = resolve }))
+
+    const store = useListsStore()
+    const initialItem = { id: 'orig', n: 'Bread', q: '1', c: 0, u: 1, d: 0 }
+    store.$patch({ lists: [{ id: 'loc-mod', n: 'List', i: [initialItem] }] })
+
+    const provisionPromise = provision({ id: 'loc-mod', n: 'List', i: [initialItem] })
+
+    store.updateItem('loc-mod', 'orig', { q: '5' })
+
+    resolveProvision({ ok: true, data: { id: 'srv-mod', authToken: 'tok-mod', role: 'owner' } })
+    await provisionPromise
+
+    const queue = JSON.parse(localStorage.getItem('pendingOps') ?? '[]') as Array<{ item: { id: string; q: string }; listId: string }>
+    const op = queue.find(o => o.item.id === 'orig' && o.listId === 'srv-mod')
+    expect(op?.item.q).toBe('5')
+  })
+
+  it('does not enqueue when no items changed during provision', async () => {
+    mProvisionList.mockResolvedValue({ ok: true, data: { id: 'srv-quiet', authToken: 'tok-quiet', role: 'owner' as const } })
+    const list = { id: 'loc-quiet', n: 'List', i: [{ id: 'a', n: 'A', q: '1', c: 0, u: 10, d: 0 }] }
+    useListsStore().$patch({ lists: [list] })
+
+    await provision(list)
+
+    expect(localStorage.getItem('pendingOps')).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary
- Snapshot the items sent in the provision body by `id → u`. After `setMeta`, walk the current local list and enqueue any item whose id is missing from the snapshot or whose `u` no longer matches.
- Closes #139.

## Why
Without this, items the user adds or modifies while the provision POST is in flight are silently dropped:
- they aren't in the provision body (snapshot taken pre-await),
- they can't be enqueued at the time (no meta yet),
- the next poll won't re-upload them.

The result is items that exist in localStorage but never reach the server.

## Test plan
- [x] `tests/unit/sync/provision-join.spec.ts` — three new tests cover the race:
  - item added mid-flight is enqueued under the new server listId,
  - item modified mid-flight is enqueued with the post-edit value,
  - no enqueue when nothing changed during provision.
- [x] `npm run lint` clean (only pre-existing warnings in generated `worker-configuration.d.ts`).
- [x] `npm run test:unit` — 215/215 pass (was 212; +3 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)