### PR TITLE
fix(List): trim item rename input; revert on whitespace-only

### DIFF
--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -141,8 +141,14 @@ function modifyItemQuantity (input: HTMLInputElement, id: string): void {
 }
 
 function modifyItemName (input: HTMLInputElement, id: string): void {
-  if (input.value) {
-    listsStore.updateItem(listId.value, id, { n: input.value })
+  const item = list.value!.i.find(i => i.id === id)
+  if (!item) return
+  const trimmed = input.value.trim()
+  if (trimmed !== '') {
+    listsStore.updateItem(listId.value, id, { n: trimmed })
+    input.value = trimmed
+  } else {
+    input.value = item.n
   }
 }
 

--- a/tests/unit/views/List.spec.ts
+++ b/tests/unit/views/List.spec.ts
@@ -149,6 +149,23 @@ describe('List.vue', () => {
     expect(qtyInput.element.value).toBe('2')
   })
 
+  it('reverts to the previous name when input is whitespace-only', async () => {
+    const { wrapper, store } = await mountList()
+    const nameInput = wrapper.find<HTMLInputElement>('.item__name')
+    await nameInput.setValue('   ')
+    await nameInput.trigger('change')
+    expect(store.lists[0].i[0].n).toBe('Apples')
+    expect(nameInput.element.value).toBe('Apples')
+  })
+
+  it('trims surrounding whitespace from a renamed item', async () => {
+    const { wrapper, store } = await mountList()
+    const nameInput = wrapper.find<HTMLInputElement>('.item__name')
+    await nameInput.setValue('  Oranges  ')
+    await nameInput.trigger('change')
+    expect(store.lists[0].i[0].n).toBe('Oranges')
+  })
+
   it('shows the all-checked banner when every active item is checked', async () => {
     const { wrapper } = await mountList([makeItem({ c: 1 })])
     expect(wrapper.text()).toContain('checked off all your items')


### PR DESCRIPTION
## Summary
- Trim the value before passing to `updateItem`; revert the input to the prior name when the trimmed value is empty (matches existing `modifyItemQuantity` behavior).
- Adds two unit tests: whitespace-only input reverts; surrounding whitespace gets trimmed before being applied.

Fixes #150

## Test plan
- [x] `npm run test:unit` — 217 pass
- [x] `npm run lint` — clean (only pre-existing worker-configuration warnings)