### PR TITLE
fix(theme-init): guard localStorage access for private/locked-down browsers

### DIFF
--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -1,6 +1,12 @@
 (function () {
-  const m = localStorage.getItem('theme-mode')
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+  let m = null
+  try {
+    m = localStorage.getItem('theme-mode')
+  } catch {
+    // localStorage can throw in private mode, locked-down enterprise configs,
+    // or file:// origins. Fall through to the prefers-color-scheme check.
+  }
   if (m === 'dark' || (m !== 'light' && prefersDark)) {
     document.documentElement.classList.add('dark')
   }

--- a/tests/unit/theme-init.spec.ts
+++ b/tests/unit/theme-init.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const scriptSrc = readFileSync(resolve(__dirname, '../../public/theme-init.js'), 'utf-8')
+
+function runScript () {
+  // The script is an IIFE; eval in a function scope so it touches the test's
+  // globals (localStorage, matchMedia, document).
+  // eslint-disable-next-line no-new-func
+  new Function(scriptSrc)()
+}
+
+function mockMatchMedia (prefersDark: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: prefersDark,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false
+    })
+  })
+}
+
+describe('theme-init.js', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.classList.remove('dark')
+    mockMatchMedia(false)
+  })
+
+  it('applies dark class when theme-mode is "dark"', () => {
+    localStorage.setItem('theme-mode', 'dark')
+    runScript()
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('does not apply dark class when theme-mode is "light"', () => {
+    localStorage.setItem('theme-mode', 'light')
+    mockMatchMedia(true)
+    runScript()
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
+  it('falls back to prefers-color-scheme when nothing is stored', () => {
+    mockMatchMedia(true)
+    runScript()
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('does not throw when localStorage.getItem throws (private mode)', () => {
+    const original = Storage.prototype.getItem
+    Storage.prototype.getItem = function () {
+      throw new DOMException('SecurityError', 'SecurityError')
+    }
+    try {
+      expect(() => runScript()).not.toThrow()
+    } finally {
+      Storage.prototype.getItem = original
+    }
+  })
+
+  it('falls back to prefers-color-scheme when localStorage throws', () => {
+    const original = Storage.prototype.getItem
+    Storage.prototype.getItem = function () {
+      throw new DOMException('SecurityError', 'SecurityError')
+    }
+    mockMatchMedia(true)
+    try {
+      runScript()
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+    } finally {
+      Storage.prototype.getItem = original
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Wrap `localStorage.getItem('theme-mode')` in try/catch. On `SecurityError` (Safari private mode historically, locked-down enterprise policies, file:// origins) the boot script no longer throws — it falls through to the `prefers-color-scheme` check.
- Adds unit tests under `tests/unit/theme-init.spec.ts` covering the happy paths plus the throwing-localStorage case.

Fixes #145

## Test plan
- [x] `npm run test:unit` — 220 pass
- [x] `npm run lint` — clean (only pre-existing worker-configuration warnings)