### PR TITLE
fix(lists): tombstones must honor LWW timestamp

### DIFF
--- a/src/stores/lists.ts
+++ b/src/stores/lists.ts
@@ -98,7 +98,7 @@ export const useListsStore = defineStore('lists', () => {
       const localIdx = existing.i.findIndex(it => it.id === inItem.id)
       if (localIdx === -1) {
         existing.i.push(inItem)
-      } else if (inItem.u > existing.i[localIdx].u || inItem.d) {
+      } else if (inItem.u > existing.i[localIdx].u) {
         existing.i[localIdx] = inItem
       }
     }

--- a/tests/unit/stores/lists.spec.ts
+++ b/tests/unit/stores/lists.spec.ts
@@ -176,5 +176,21 @@ describe('lists store', () => {
       expect(store.lists[0].i).toHaveLength(1)
       expect(store.lists[0].i[0].d).toBe(1)
     })
+
+    it('ignores an incoming tombstone that is older than the local edit', () => {
+      const store = useListsStore()
+      store.createList({ id: 'abc', n: 'L', i: [{ id: 'a', n: 'Apples', q: '99', c: 0, u: 200, d: 0 }] })
+      // Stale/replayed delete with an older timestamp must not clobber a fresher local edit.
+      store.mergeList({ id: 'abc', n: 'L', i: [{ id: 'a', n: 'Apples', q: '1', c: 0, u: 100, d: 1 }] })
+      expect(store.lists[0].i[0].d).toBe(0)
+      expect(store.lists[0].i[0].q).toBe('99')
+    })
+
+    it('accepts an incoming tombstone newer than the local edit', () => {
+      const store = useListsStore()
+      store.createList({ id: 'abc', n: 'L', i: [{ id: 'a', n: 'Apples', q: '1', c: 0, u: 100, d: 0 }] })
+      store.mergeList({ id: 'abc', n: 'L', i: [{ id: 'a', n: 'Apples', q: '1', c: 0, u: 200, d: 1 }] })
+      expect(store.lists[0].i[0].d).toBe(1)
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Drops the `|| inItem.d` short-circuit in \`mergeList\` so tombstones are subject to the same last-writer-wins rule as any other update.
- Adds two tests: a stale incoming tombstone is ignored; a newer tombstone is accepted.

Fixes #141

## Test plan
- [x] \`npm run test:unit\` — 217 pass