### PR TITLE
fix(api/join): exclude tombstoned items from the join payload

### DIFF
--- a/functions/api/_shared/handlers.ts
+++ b/functions/api/_shared/handlers.ts
@@ -164,11 +164,14 @@ export async function handleJoin (
   if (!list) return Response.json({ error: 'Not Found' }, { status: 404 })
 
   const { results: items } = await db.prepare(
-    'SELECT id, n, q, c, u, d FROM items WHERE list_id = ?'
+    'SELECT id, n, q, c, u, d FROM items WHERE list_id = ? AND d = 0'
   ).bind(listId).all<ItemRow>()
 
-  const maxItemU = items.reduce((m, i) => Math.max(m, i.u), 0)
-  const cursor = Math.max(list.u, maxItemU)
+  const maxItemU = await db.prepare(
+    'SELECT COALESCE(MAX(u), 0) AS m FROM items WHERE list_id = ?'
+  ).bind(listId).first<{ m: number }>()
+
+  const cursor = Math.max(list.u, maxItemU?.m ?? 0)
 
   return Response.json({
     listId: list.id,

--- a/tests/integration/api/lists.spec.ts
+++ b/tests/integration/api/lists.spec.ts
@@ -256,6 +256,30 @@ describe('POST /api/lists/:id/join', () => {
     }
   })
 
+  it('does not return soft-deleted items in the join payload', async () => {
+    const { id, authToken } = await provision()
+    const upsertReq = (itemId: string, item: object) => new Request(`http://localhost/api/lists/${id}/items/${itemId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` },
+      body: JSON.stringify(item)
+    })
+    await handleUpsertItem(db, upsertReq('live01', { n: 'Milk', q: '1', c: 0, u: 1000, d: 0 }), id, 'live01')
+    await handleUpsertItem(db, upsertReq('dead01', { n: 'Bread', q: '1', c: 0, u: 1500, d: 0 }), id, 'dead01')
+    await handleUpsertItem(db, upsertReq('dead01', { n: 'Bread', q: '1', c: 0, u: 2000, d: 1 }), id, 'dead01')
+
+    const req = new Request(`http://localhost/api/lists/${id}/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: authToken })
+    })
+    const res = await handleJoin(db, req, id)
+    const body = await res.json() as { items: Array<{ id: string }>, cursor: number }
+    const ids = body.items.map(i => i.id)
+    expect(ids).toEqual(['live01'])
+    // Cursor still reflects the latest write (including the tombstone) so poll deltas line up.
+    expect(body.cursor).toBe(2000)
+  })
+
   it('returns 401 when token belongs to a different list', async () => {
     const { authToken } = await provision('List A')
     const { id: otherId } = await provision('List B')


### PR DESCRIPTION
## Summary
- Adds \`AND d = 0\` to the items SELECT in \`handleJoin\`.
- Computes cursor with a separate \`MAX(u)\` query so deltas still line up with the latest tombstone write (matches \`handlePoll\`).
- Integration test asserts tombstones are absent from the join payload while the cursor still reflects the tombstone's \`u\`.

Fixes #144

## Test plan
- [x] \`npm run test:integration\` — 47 pass
- [x] \`npm run test:unit\` — 215 pass