### PR TITLE
fix(api/tokens): replace prior editor rows on mint; delete on revoke

### DIFF
--- a/functions/api/_shared/handlers.ts
+++ b/functions/api/_shared/handlers.ts
@@ -196,9 +196,14 @@ export async function handleMintToken (
   const tokenHash = await hashToken(authToken)
   const now = Date.now()
 
-  await db.prepare(
-    'INSERT INTO list_tokens (token_hash, list_id, role, created_at) VALUES (?, ?, ?, ?)'
-  ).bind(tokenHash, listId, 'editor', now).run()
+  // Replace any prior editor rows for this list so enable/disable cycles
+  // don't grow list_tokens unbounded over the lifetime of a list.
+  await db.batch([
+    db.prepare('DELETE FROM list_tokens WHERE list_id = ? AND role = ?').bind(listId, 'editor'),
+    db.prepare(
+      'INSERT INTO list_tokens (token_hash, list_id, role, created_at) VALUES (?, ?, ?, ?)'
+    ).bind(tokenHash, listId, 'editor', now)
+  ])
 
   return Response.json({ token: authToken })
 }
@@ -216,8 +221,8 @@ export async function handleRevokeToken (
   }
 
   await db.prepare(
-    'UPDATE list_tokens SET revoked_at = ? WHERE list_id = ? AND role = ?'
-  ).bind(Date.now(), listId, 'editor').run()
+    'DELETE FROM list_tokens WHERE list_id = ? AND role = ?'
+  ).bind(listId, 'editor').run()
 
   return Response.json({})
 }

--- a/tests/integration/api/lists.spec.ts
+++ b/tests/integration/api/lists.spec.ts
@@ -568,6 +568,25 @@ describe('POST /api/lists/:id/tokens', () => {
     const res = await handleMintToken(db, new Request(`http://localhost/api/lists/${id}/tokens`, { method: 'POST' }), id)
     expect(res.status).toBe(401)
   })
+
+  it('replaces prior editor rows on mint so list_tokens does not grow unbounded', async () => {
+    const { id, authToken } = await setup()
+    const countEditors = async () => {
+      const row = await db.prepare('SELECT COUNT(*) AS c FROM list_tokens WHERE list_id = ? AND role = ?')
+        .bind(id, 'editor').first<{ c: number }>()
+      return row?.c ?? 0
+    }
+    // Three enable→revoke cycles should not leave three editor rows behind.
+    for (let i = 0; i < 3; i++) {
+      await handleMintToken(db, mintReq(id, authToken), id)
+      await handleRevokeToken(db, new Request(`http://localhost/api/lists/${id}/tokens/revoke`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${authToken}` }
+      }), id)
+    }
+    await handleMintToken(db, mintReq(id, authToken), id)
+    expect(await countEditors()).toBe(1)
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -628,6 +647,18 @@ describe('POST /api/lists/:id/tokens/revoke', () => {
       method: 'POST'
     }), id)
     expect(res.status).toBe(401)
+  })
+
+  it('deletes editor rows so list_tokens does not retain revoked entries', async () => {
+    const { id, authToken } = await setup()
+    await handleMintToken(db, new Request(`http://localhost/api/lists/${id}/tokens`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${authToken}` }
+    }), id)
+    await handleRevokeToken(db, revokeReq(id, authToken), id)
+    const row = await db.prepare('SELECT COUNT(*) AS c FROM list_tokens WHERE list_id = ? AND role = ?')
+      .bind(id, 'editor').first<{ c: number }>()
+    expect(row?.c ?? 0).toBe(0)
   })
 })
 


### PR DESCRIPTION
## Summary
- \`handleMintToken\` now wraps the INSERT in a batch with \`DELETE FROM list_tokens WHERE list_id = ? AND role = 'editor'\` so prior editor rows are replaced.
- \`handleRevokeToken\` now DELETEs editor rows instead of marking \`revoked_at\`.
- Adds integration tests asserting a single editor row after multiple enable/revoke cycles, and zero editor rows after a revoke.

The \`revoked_at\` column is left in place on the schema for now; no code path writes to it after this change, but a column drop is a separate ALTER that wasn't requested in the issue.

Fixes #143

## Test plan
- [x] \`npm run test:integration\` — 48 pass
- [x] \`npm run test:unit\` — 215 pass