### PR TITLE
chore(rename): drop dead list-rename wiring

### DIFF
--- a/functions/api/_shared/handlers.ts
+++ b/functions/api/_shared/handlers.ts
@@ -110,8 +110,8 @@ export async function handlePoll (
   }
 
   const list = await db.prepare(
-    'SELECT id, name, u, version FROM lists WHERE id = ?'
-  ).bind(listId).first<ListRow>()
+    'SELECT id, u, version FROM lists WHERE id = ?'
+  ).bind(listId).first<Pick<ListRow, 'id' | 'u' | 'version'>>()
 
   if (!list) return Response.json({ error: 'Not Found' }, { status: 404 })
 
@@ -125,13 +125,7 @@ export async function handlePoll (
 
   const cursor = Math.max(list.u, maxItemU?.m ?? 0)
 
-  const payload: Record<string, unknown> = { version: list.version, cursor, items }
-  if (list.u > since) {
-    payload.name = list.name
-    payload.nameUpdatedAt = list.u
-  }
-
-  return Response.json(payload)
+  return Response.json({ version: list.version, cursor, items })
 }
 
 export async function handleJoin (
@@ -158,8 +152,8 @@ export async function handleJoin (
   }
 
   const list = await db.prepare(
-    'SELECT id, name, u, version FROM lists WHERE id = ?'
-  ).bind(listId).first<ListRow>()
+    'SELECT id, name, u FROM lists WHERE id = ?'
+  ).bind(listId).first<Pick<ListRow, 'id' | 'name' | 'u'>>()
 
   if (!list) return Response.json({ error: 'Not Found' }, { status: 404 })
 
@@ -174,7 +168,6 @@ export async function handleJoin (
     listId: list.id,
     role: ROLES.editor,
     name: list.name,
-    version: list.version,
     cursor,
     items
   })

--- a/src/sync/reconcile.ts
+++ b/src/sync/reconcile.ts
@@ -8,7 +8,7 @@ export function applyPollPayload (listId: string, payload: PollPayload): void {
 
   store.mergeList({
     id: listId,
-    n: payload.name ?? existing.n,
+    n: existing.n,
     i: payload.items.map(item => ({
       id: item.id, n: item.n, q: item.q, c: item.c, u: item.u, d: item.d
     }))

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -13,8 +13,6 @@ export type SyncMetaMap = Record<string, SyncMeta>
 
 export interface PollPayload {
   cursor: number
-  name?: string
-  nameUpdatedAt?: number
   items: ItemPayload[]
 }
 
@@ -37,7 +35,6 @@ export interface JoinResponse {
   listId: string
   role: Role
   name: string
-  version: number
   cursor: number
   items: ItemPayload[]
 }

--- a/tests/integration/api/lists.spec.ts
+++ b/tests/integration/api/lists.spec.ts
@@ -209,11 +209,10 @@ describe('POST /api/lists/:id/join', () => {
     })
     const res = await handleJoin(db, req, id)
     expect(res.status).toBe(200)
-    const body = await res.json() as { listId: string; role: string; name: string; version: number; cursor: number; items: unknown[] }
+    const body = await res.json() as { listId: string; role: string; name: string; cursor: number; items: unknown[] }
     expect(body.listId).toBe(id)
     expect(body.role).toBe('editor')
     expect(body.name).toBe('Test List')
-    expect(body.version).toBe(1)
     expect(body.cursor).toBe(0)
     expect(body.items).toEqual([])
   })

--- a/tests/unit/sync/reconcile.spec.ts
+++ b/tests/unit/sync/reconcile.spec.ts
@@ -19,12 +19,12 @@ describe('sync/reconcile', () => {
     it('merges server items into the local list', () => {
       const store = useListsStore()
       store.$patch({ lists: [{ id: 'abc', n: 'Groceries', i: [] }] })
-      applyPollPayload('abc', { cursor: 2, name: 'Groceries', items: [ITEM] })
+      applyPollPayload('abc', { cursor: 2, items: [ITEM] })
       expect(store.lists[0].i).toHaveLength(1)
       expect(store.lists[0].i[0].n).toBe('Milk')
     })
 
-    it('preserves local name when payload omits name', () => {
+    it('preserves the local name across a poll', () => {
       const store = useListsStore()
       store.$patch({ lists: [{ id: 'abc', n: 'My List', i: [] }] })
       applyPollPayload('abc', { cursor: 1, items: [] })
@@ -35,7 +35,7 @@ describe('sync/reconcile', () => {
   describe('applyJoinPayload', () => {
     it('inserts the incoming list when absent', () => {
       const store = useListsStore()
-      applyJoinPayload({ listId: 's1', role: 'editor', name: 'Shared', version: 1, cursor: 5, items: [ITEM] })
+      applyJoinPayload({ listId: 's1', role: 'editor', name: 'Shared', cursor: 5, items: [ITEM] })
       expect(store.lists).toHaveLength(1)
       expect(store.lists[0].n).toBe('Shared')
       expect(store.lists[0].i[0].n).toBe('Milk')
@@ -44,7 +44,7 @@ describe('sync/reconcile', () => {
     it('replaces an existing list with the same id', () => {
       const store = useListsStore()
       store.$patch({ lists: [{ id: 's1', n: 'Old', i: [] }] })
-      applyJoinPayload({ listId: 's1', role: 'editor', name: 'Updated', version: 2, cursor: 2, items: [] })
+      applyJoinPayload({ listId: 's1', role: 'editor', name: 'Updated', cursor: 2, items: [] })
       expect(store.lists).toHaveLength(1)
       expect(store.lists[0].n).toBe('Updated')
     })


### PR DESCRIPTION
## Summary
Picks option 1 from the issue: deletes the half-built rename wiring rather than finishing the feature.

- \`handlePoll\` response: drops \`name\` and \`nameUpdatedAt\` (and removes \`name\` from the \`lists\` SELECT).
- \`handleJoin\` response: drops \`version\` (and removes \`version\` from the \`lists\` SELECT).
- \`PollPayload\`: drops \`name?\` and \`nameUpdatedAt?\`.
- \`JoinResponse\`: drops \`version\`.
- \`applyPollPayload\`: drops the \`payload.name ?? existing.n\` blind overwrite — passes \`existing.n\` through unchanged. (Note: \`mergeList\` doesn't read \`n\` anyway, so this is defensive.)
- Updates the reconcile unit test and the join integration test to match the trimmed shapes.

Fixes #140

## Test plan
- [x] \`npm run test:unit\` — 215 pass
- [x] \`npm run test:integration\` — 46 pass
- [x] \`npm run type-check\` — clean