### PR TITLE
chore(schema): drop unused items_by_tombstone index

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -29,4 +29,3 @@ CREATE TABLE IF NOT EXISTS items (
 );
 
 CREATE INDEX IF NOT EXISTS items_by_version ON items(list_id, u);
-CREATE INDEX IF NOT EXISTS items_by_tombstone ON items(d, u);


### PR DESCRIPTION
Closes #146

## Problem
`schema.sql` defined `CREATE INDEX items_by_tombstone ON items(d, u)`. No
query filters on `d` as a leading predicate. The only `d`-filtering query
(`handlers.ts:164`, `WHERE list_id = ? AND d = 0`) keys on `list_id` first,
already served by `items_by_version (list_id, u)`. The `(d, u)` index gave
zero read benefit and added write amplification on every items upsert.

## Change
- Remove the `items_by_tombstone` index from `schema.sql`.

## Production note
`schema.sql` uses `CREATE INDEX IF NOT EXISTS`, so fresh DBs are correct.
An existing D1 database needs a one-off `DROP INDEX items_by_tombstone;`
applied manually — no migration framework exists in this repo.

## Testing
- Integration suite: 50 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)