### PR TITLE
fix(sync): purge pending ops on leaveList/deleteList

### DIFF
--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -4,7 +4,7 @@ import { provisionList, joinList, mintToken, revokeToken, deleteListRequest } fr
 import { applyJoinPayload } from './reconcile'
 import { getMeta, setMeta, getSyncMetaMap, saveSyncMetaMap } from './storage'
 import { startPoller, stopPoller } from './poll'
-import { startDrainer, enqueue } from './queue'
+import { startDrainer, enqueue, purgeOpsForList } from './queue'
 import { cleanupListLocally } from './cleanup'
 
 export { getMeta, getSyncMetaMap, saveSyncMetaMap } from './storage'
@@ -126,11 +126,13 @@ export async function deleteList (listId: string): Promise<boolean> {
   if (!result.ok) return false
 
   stopPoller(listId)
+  purgeOpsForList(listId)
   cleanupListLocally(listId)
   return true
 }
 
 export function leaveList (listId: string): void {
   stopPoller(listId)
+  purgeOpsForList(listId)
   cleanupListLocally(listId)
 }

--- a/src/sync/queue.ts
+++ b/src/sync/queue.ts
@@ -73,7 +73,7 @@ function removeOpById (opId: string): void {
   saveQueue(loadQueue().filter(o => o.opId !== opId))
 }
 
-function removeOpsByListId (listId: string): void {
+export function purgeOpsForList (listId: string): void {
   saveQueue(loadQueue().filter(o => o.listId !== listId))
 }
 
@@ -115,7 +115,7 @@ async function flush (): Promise<void> {
     const op = q[0]
     const meta = getMeta(op.listId)
     if (!meta) {
-      removeOpsByListId(op.listId)
+      purgeOpsForList(op.listId)
       continue
     }
 
@@ -136,7 +136,7 @@ async function flush (): Promise<void> {
           : `"${listName}" was deleted.`,
         'error'
       )
-      removeOpsByListId(op.listId)
+      purgeOpsForList(op.listId)
       cleanupListLocally(op.listId)
     } else {
       await sleep(backoffMs)

--- a/tests/unit/sync/owner-actions.spec.ts
+++ b/tests/unit/sync/owner-actions.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { enableSharing, disableSharing, deleteList, leaveList } from '@/sync'
 import { mintToken, revokeToken, deleteListRequest } from '@/sync/transport'
 import { stopPoller } from '@/sync/poll'
+import { purgeOpsForList } from '@/sync/queue'
 import { cleanupListLocally } from '@/sync/cleanup'
 import { getMeta, setMeta } from '@/sync/storage'
 
@@ -14,7 +15,7 @@ vi.mock('@/sync/transport', () => ({
 }))
 vi.mock('@/sync/poll', () => ({ startPoller: vi.fn(), stopPoller: vi.fn() }))
 vi.mock('@/sync/cleanup', () => ({ cleanupListLocally: vi.fn() }))
-vi.mock('@/sync/queue', () => ({ startDrainer: vi.fn(), enqueue: vi.fn() }))
+vi.mock('@/sync/queue', () => ({ startDrainer: vi.fn(), enqueue: vi.fn(), purgeOpsForList: vi.fn() }))
 vi.mock('@/sync/reconcile', () => ({ applyJoinPayload: vi.fn() }))
 vi.mock('@/stores/lists', () => ({ useListsStore: vi.fn() }))
 
@@ -22,6 +23,7 @@ const mMintToken = vi.mocked(mintToken)
 const mRevokeToken = vi.mocked(revokeToken)
 const mDeleteListRequest = vi.mocked(deleteListRequest)
 const mStopPoller = vi.mocked(stopPoller)
+const mPurgeOpsForList = vi.mocked(purgeOpsForList)
 const mCleanupListLocally = vi.mocked(cleanupListLocally)
 
 const OWNER_META = { authToken: 'owner-tok', role: 'owner' as const, lastCursor: 1 }
@@ -112,21 +114,30 @@ describe('deleteList', () => {
     expect(mStopPoller).not.toHaveBeenCalled()
   })
 
-  it('returns true and calls stopPoller + cleanupListLocally on success', async () => {
+  it('returns true and calls stopPoller + purgeOpsForList + cleanupListLocally on success', async () => {
     setMeta('list1', OWNER_META)
     mDeleteListRequest.mockResolvedValue({ ok: true, data: {} as Record<string, never> })
 
     expect(await deleteList('list1')).toBe(true)
     expect(mDeleteListRequest).toHaveBeenCalledWith('list1', 'owner-tok')
     expect(mStopPoller).toHaveBeenCalledWith('list1')
+    expect(mPurgeOpsForList).toHaveBeenCalledWith('list1')
     expect(mCleanupListLocally).toHaveBeenCalledWith('list1')
+  })
+
+  it('does not purge ops when server returns error', async () => {
+    setMeta('list1', OWNER_META)
+    mDeleteListRequest.mockResolvedValue({ ok: false, error: { kind: 'network' } })
+    expect(await deleteList('list1')).toBe(false)
+    expect(mPurgeOpsForList).not.toHaveBeenCalled()
   })
 })
 
 describe('leaveList', () => {
-  it('calls stopPoller and cleanupListLocally', () => {
+  it('calls stopPoller, purgeOpsForList and cleanupListLocally', () => {
     leaveList('list1')
     expect(mStopPoller).toHaveBeenCalledWith('list1')
+    expect(mPurgeOpsForList).toHaveBeenCalledWith('list1')
     expect(mCleanupListLocally).toHaveBeenCalledWith('list1')
   })
 })


### PR DESCRIPTION
Closes #148

## Problem
`cleanupListLocally` intentionally does not touch `pendingOps` — the drainer
purges them lazily on its next `flush()` pass when `getMeta` returns null.
If the user leaves/deletes a list and immediately closes the tab, those ops
linger in localStorage until the next session triggers `startDrainer()`.

## Change
- Rename the queue's private `removeOpsByListId` to an exported
  `purgeOpsForList(listId)` (drain-path call sites updated; behaviour
  unchanged).
- `leaveList` and `deleteList` (`src/sync/index.ts`) now call
  `purgeOpsForList` synchronously before `cleanupListLocally`. For
  `deleteList` this runs only after the server delete succeeds.

## Testing
- `owner-actions.spec.ts`: new assertions that `purgeOpsForList` runs on
  leave and on successful delete, and is skipped when the delete request
  fails. Sync unit suites: 33 passed.
- `vue-tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)