### PR TITLE
perf(sync): cache parsed syncMeta map

### DIFF
--- a/src/sync/storage.ts
+++ b/src/sync/storage.ts
@@ -3,7 +3,14 @@ import type { SyncMeta, SyncMetaMap } from './types'
 const KEY = 'syncMeta'
 const CORRUPTED_PREFIX = 'syncMeta.corrupted.'
 
-export function getSyncMetaMap (): SyncMetaMap {
+// Parsed-map cache. This tab only ever mutates `syncMeta` through
+// saveSyncMetaMap, so the cache stays authoritative until then. A `storage`
+// event means another tab wrote the key, so we drop the cache and re-parse
+// on the next read. getMeta/getSyncMetaMap sit on sync hot paths (every poll
+// and every drain iteration); without the cache each call re-parsed JSON.
+let cache: SyncMetaMap | null = null
+
+function parseFromStorage (): SyncMetaMap {
   const raw = localStorage.getItem(KEY)
   if (raw === null) return {}
   try {
@@ -19,6 +26,11 @@ export function getSyncMetaMap (): SyncMetaMap {
   }
 }
 
+export function getSyncMetaMap (): SyncMetaMap {
+  if (cache === null) cache = parseFromStorage()
+  return cache
+}
+
 function backupCorrupted (raw: string, reason: unknown): void {
   const backupKey = `${CORRUPTED_PREFIX}${Date.now()}`
   console.warn('[sync/storage] corrupted syncMeta — preserving to', backupKey, reason)
@@ -32,6 +44,7 @@ function backupCorrupted (raw: string, reason: unknown): void {
 
 export function saveSyncMetaMap (map: SyncMetaMap): void {
   localStorage.setItem(KEY, JSON.stringify(map))
+  cache = map
 }
 
 export function getMeta (listId: string): SyncMeta | null {
@@ -48,4 +61,17 @@ export function removeMeta (listId: string): void {
   const map = getSyncMetaMap()
   delete map[listId]
   saveSyncMetaMap(map)
+}
+
+// Drop the cache when another tab rewrites syncMeta (or clears storage).
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (e: StorageEvent) => {
+    if (e.key === KEY || e.key === null) cache = null
+  })
+}
+
+// Clears the in-memory cache. Tests manipulate localStorage directly, which
+// bypasses saveSyncMetaMap; the unit setup calls this before each test.
+export function _resetForTest (): void {
+  cache = null
 }

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -1,3 +1,6 @@
+import { beforeEach } from 'vitest'
+import { _resetForTest as resetSyncMetaCache } from '@/sync/storage'
+
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   configurable: true,
@@ -8,4 +11,11 @@ Object.defineProperty(window, 'matchMedia', {
     removeEventListener: () => {},
     dispatchEvent: () => false
   })
+})
+
+// storage.ts caches the parsed syncMeta map in module state. Tests poke
+// localStorage directly (and call localStorage.clear()), which bypasses the
+// cache, so reset it before every test to keep cases isolated.
+beforeEach(() => {
+  resetSyncMetaCache()
 })

--- a/tests/unit/sync/storage.spec.ts
+++ b/tests/unit/sync/storage.spec.ts
@@ -72,4 +72,30 @@ describe('sync/storage', () => {
     removeMeta('gone')
     expect(getMeta('keep')).toEqual(META)
   })
+
+  it('getSyncMetaMap returns a stable cached reference across calls', () => {
+    setMeta('abc', META)
+    expect(getSyncMetaMap()).toBe(getSyncMetaMap())
+  })
+
+  it('getSyncMetaMap serves the cache without re-reading localStorage', () => {
+    setMeta('abc', META)
+    // Direct write bypasses saveSyncMetaMap, so the cache must not see it.
+    localStorage.setItem('syncMeta', JSON.stringify({ xyz: META }))
+    expect(getSyncMetaMap()).toEqual({ abc: META })
+  })
+
+  it('a storage event for syncMeta invalidates the cache', () => {
+    setMeta('abc', META)
+    localStorage.setItem('syncMeta', JSON.stringify({ xyz: META }))
+    window.dispatchEvent(new StorageEvent('storage', { key: 'syncMeta' }))
+    expect(getSyncMetaMap()).toEqual({ xyz: META })
+  })
+
+  it('a storage event for an unrelated key leaves the cache intact', () => {
+    setMeta('abc', META)
+    localStorage.setItem('syncMeta', JSON.stringify({ xyz: META }))
+    window.dispatchEvent(new StorageEvent('storage', { key: 'somethingElse' }))
+    expect(getSyncMetaMap()).toEqual({ abc: META })
+  })
 })


### PR DESCRIPTION
Closes #149

## Problem
`getSyncMetaMap` read and `JSON.parse`'d localStorage on every call. It sits
on sync hot paths — `getMeta` delegates to it, and `getMeta` runs once per
poll iteration (`poll.ts`) and once per drain iteration (`queue.ts`). With
pollers active across many lists the repeated parse adds up.

## Change
- Cache the parsed map in module state in `src/sync/storage.ts`.
  `saveSyncMetaMap` refreshes the cache, so this tab's reads stay
  authoritative.
- A `storage` event — another tab wrote `syncMeta`, or cleared storage —
  drops the cache, so the next read re-parses. This preserves the cross-tab
  freshness the uncached version had for free.
- New `_resetForTest` export; the unit setup resets the cache before each
  test (tests poke localStorage directly, bypassing `saveSyncMetaMap`).

## Testing
- Full unit suite: 229 passed.
- New `storage.spec.ts` cases: stable cached reference, cache served without
  re-reading localStorage, `storage` event invalidates the cache, unrelated
  key leaves it intact.
- `vue-tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)