### PR TITLE
fix(lists): guard deleteList index and quarantine corrupt lists key

### DIFF
--- a/src/stores/lists.ts
+++ b/src/stores/lists.ts
@@ -33,9 +33,30 @@ export const useListsStore = defineStore('lists', () => {
     }
   }
 
+  function quarantineCorruptedLists (raw: string, reason: unknown): void {
+    const backupKey = `lists.corrupted.${Date.now()}`
+    console.warn('[lists] corrupted lists key — preserving to', backupKey, reason)
+    try {
+      localStorage.setItem(backupKey, raw)
+      localStorage.removeItem('lists')
+    } catch {
+      // Quota or storage gone — continue with empty state regardless.
+    }
+  }
+
   function init () {
     const raw = localStorage.getItem('lists')
-    if (raw) lists.value = JSON.parse(raw)
+    if (raw === null) return
+    try {
+      const parsed = JSON.parse(raw) as unknown
+      if (!Array.isArray(parsed)) {
+        quarantineCorruptedLists(raw, 'unexpected shape')
+        return
+      }
+      lists.value = parsed as List[]
+    } catch (err) {
+      quarantineCorruptedLists(raw, err)
+    }
   }
 
   function writeList (listId: string, mutator: (list: List) => void) {
@@ -53,7 +74,9 @@ export const useListsStore = defineStore('lists', () => {
   }
 
   function deleteList (id: string) {
-    lists.value.splice(lists.value.findIndex(l => l.id === id), 1)
+    const idx = lists.value.findIndex(l => l.id === id)
+    if (idx === -1) return
+    lists.value.splice(idx, 1)
     persist()
   }
 

--- a/tests/unit/stores/lists.spec.ts
+++ b/tests/unit/stores/lists.spec.ts
@@ -30,6 +30,35 @@ describe('lists store', () => {
     expect(store.lists).toEqual([])
   })
 
+  describe('init corruption handling', () => {
+    afterEach(() => vi.restoreAllMocks())
+
+    it('quarantines an unparseable lists key and continues with empty state', () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+      localStorage.setItem('lists', '{not valid json')
+      const store = useListsStore()
+
+      expect(() => store.init()).not.toThrow()
+      expect(store.lists).toEqual([])
+      expect(localStorage.getItem('lists')).toBeNull()
+
+      const backup = Object.keys(localStorage).find(k => k.startsWith('lists.corrupted.'))
+      expect(backup).toBeDefined()
+      expect(localStorage.getItem(backup!)).toBe('{not valid json')
+    })
+
+    it('quarantines a lists key holding a non-array value', () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+      localStorage.setItem('lists', JSON.stringify({ id: 'a', n: 'oops' }))
+      const store = useListsStore()
+
+      expect(() => store.init()).not.toThrow()
+      expect(store.lists).toEqual([])
+      expect(localStorage.getItem('lists')).toBeNull()
+      expect(Object.keys(localStorage).some(k => k.startsWith('lists.corrupted.'))).toBe(true)
+    })
+  })
+
   it('createList appends a list and persists', () => {
     const store = useListsStore()
     store.createList(new List('Groceries', []))
@@ -45,6 +74,17 @@ describe('lists store', () => {
     store.deleteList(list.id)
     expect(store.lists).toHaveLength(0)
     expect(JSON.parse(localStorage.getItem('lists') ?? '[]')).toHaveLength(0)
+  })
+
+  it('deleteList is a no-op for a missing id and keeps other lists', () => {
+    const store = useListsStore()
+    const a = new List('A', [])
+    const b = new List('B', [])
+    store.createList(a)
+    store.createList(b)
+    store.deleteList('does-not-exist')
+    expect(store.lists).toHaveLength(2)
+    expect(JSON.parse(localStorage.getItem('lists') ?? '[]')).toHaveLength(2)
   })
 
   it('addItem sorts items alphabetically by name', () => {


### PR DESCRIPTION
## Summary

Resolves two P1 data-loss bugs in `useListsStore`.

### #163 — `deleteList()` removes the last list on a missing id
`deleteList()` passed `findIndex`'s result straight into `splice`. A missing id yields `-1`, and `splice(-1, 1)` removes the **last** list — silently destroying unrelated user data. Now guards the index and no-ops when the id is absent.

### #164 — corrupt `lists` localStorage key bricks the app
`init()` ran `JSON.parse` on the `lists` key with no error handling. A corrupt key threw inside `App.vue` `onMounted` *before* `loaded.value = true`, leaving a permanent blank screen with no recovery. Now wraps the parse, validates the array shape, and quarantines corrupt data to a `lists.corrupted.*` key — matching the pattern already used in `sync/queue.ts` and `sync/storage.ts`.

## Tests
- `deleteList` no-op for a missing id (keeps other lists, persists)
- `init` quarantines unparseable JSON, continues with empty state
- `init` quarantines a non-array value

All 24 lists-store unit tests pass; typecheck and lint clean.

Closes #163
Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)