### PR TITLE
chore(eslint): ignore generated worker-configuration.d.ts

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import vueStandard from '@vue/eslint-config-standard'
 import tseslint from 'typescript-eslint'
 
 export default [
-  { ignores: ['dist/**', 'node_modules/**', 'coverage/**', '.wrangler/**'] },
+  { ignores: ['dist/**', 'node_modules/**', 'coverage/**', '.wrangler/**', 'worker-configuration.d.ts'] },
   js.configs.recommended,
   { languageOptions: { globals: { ...globals.browser, ...globals.node } } },
   ...tseslint.configs.recommended,


### PR DESCRIPTION
## Summary
`worker-configuration.d.ts` is gitignored (generated by `wrangler types`) but was not in the eslint `ignores` list, so `npm run lint` reported 2 `Unused eslint-disable directive` warnings against it — the only lint output in the repo.

Adds `worker-configuration.d.ts` to the `ignores` array in `eslint.config.js`.

## Testing
- `npm run lint` — now clean, no output

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)