### PR TITLE
fix(list): bind quantity input with v-model.number

### DIFF
--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -19,7 +19,7 @@
              type="text" id="name" placeholder="Item Name"/>
 
       <label for="quantity" class="sr-only">Quantity</label>
-      <input v-model="quantity" required
+      <input v-model.number="quantity" required
              class="new-item__input new-item__input--number"
              min="1" max="2147483647"
              type="number" id="quantity"/>


### PR DESCRIPTION
## Summary
In `List.vue`, `quantity` is declared `ref<number>(1)` but was bound to `<input type="number">` via plain `v-model` — **without** the `.number` modifier. At runtime the ref therefore held a `string`, contradicting its declared type. `String(quantity.value)` in `addItemToList` masked the mismatch.

Adds `.number` to the `v-model` so the runtime value matches the declared `number` type.

## Testing
- `npx vitest run tests/unit/views/List.spec.ts` — 19 passed

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)