### PR TITLE
feat(lists): GC soft-deleted item tombstones locally

### DIFF
--- a/src/stores/lists.ts
+++ b/src/stores/lists.ts
@@ -10,6 +10,12 @@ function sortItems (list: List) {
   list.i.sort((a, b) => a.n.localeCompare(b.n, undefined, { sensitivity: 'base' }))
 }
 
+// Soft-deleted items (`d = 1`) are pruned from localStorage once they are
+// older than the server's tombstone GC window. By then the server has
+// already dropped them (.github/workflows/gc-tombstones.yml), so no poll
+// can re-deliver them — keeping them locally is just unbounded growth.
+const TOMBSTONE_TTL_MS = 90 * 24 * 60 * 60 * 1000
+
 export const useListsStore = defineStore('lists', () => {
   const lists = ref<List[]>([])
   let lastPersistFailed = false
@@ -44,6 +50,28 @@ export const useListsStore = defineStore('lists', () => {
     }
   }
 
+  // Prunes soft-deleted items older than the server GC window. A synced
+  // list also requires the tombstone to sit at or below `lastCursor` — i.e.
+  // this client has already polled past it — so a not-yet-synced local
+  // delete is never dropped before the server has seen it.
+  function gcTombstones () {
+    const cutoff = Date.now() - TOMBSTONE_TTL_MS
+    let pruned = false
+    for (const list of lists.value) {
+      const meta = getMeta(list.id)
+      const kept = list.i.filter(item => {
+        if (item.d !== 1 || item.u >= cutoff) return true
+        if (meta && item.u >= (meta.lastCursor ?? 0)) return true
+        return false
+      })
+      if (kept.length !== list.i.length) {
+        list.i = kept
+        pruned = true
+      }
+    }
+    if (pruned) persist()
+  }
+
   function init () {
     const raw = localStorage.getItem('lists')
     if (raw === null) return
@@ -54,6 +82,7 @@ export const useListsStore = defineStore('lists', () => {
         return
       }
       lists.value = parsed as List[]
+      gcTombstones()
     } catch (err) {
       quarantineCorruptedLists(raw, err)
     }
@@ -144,6 +173,7 @@ export const useListsStore = defineStore('lists', () => {
     lists,
     getListFromId,
     init,
+    gcTombstones,
     createList,
     deleteList,
     addItem,

--- a/tests/unit/stores/lists.spec.ts
+++ b/tests/unit/stores/lists.spec.ts
@@ -59,6 +59,67 @@ describe('lists store', () => {
     })
   })
 
+  describe('tombstone GC', () => {
+    const DAY = 24 * 60 * 60 * 1000
+    const item = (id: string, u: number, d: number) => ({ id, n: id, q: '1', c: 0, u, d })
+
+    it('init prunes soft-deleted items older than the 90-day window', () => {
+      const now = Date.now()
+      localStorage.setItem('lists', JSON.stringify([
+        { id: 'a', n: 'L', i: [item('stale', now - 91 * DAY, 1), item('fresh', now - DAY, 1)] }
+      ]))
+      const store = useListsStore()
+      store.init()
+      expect(store.lists[0].i.map(i => i.id)).toEqual(['fresh'])
+    })
+
+    it('init keeps active items regardless of age', () => {
+      const now = Date.now()
+      localStorage.setItem('lists', JSON.stringify([
+        { id: 'a', n: 'L', i: [item('old-active', now - 365 * DAY, 0)] }
+      ]))
+      const store = useListsStore()
+      store.init()
+      expect(store.lists[0].i.map(i => i.id)).toEqual(['old-active'])
+    })
+
+    it('init persists the pruned lists key', () => {
+      const now = Date.now()
+      localStorage.setItem('lists', JSON.stringify([
+        { id: 'a', n: 'L', i: [item('stale', now - 91 * DAY, 1)] }
+      ]))
+      useListsStore().init()
+      const persisted = JSON.parse(localStorage.getItem('lists') ?? '[]')
+      expect(persisted[0].i).toEqual([])
+    })
+
+    it('init keeps a stale tombstone the sync cursor has not passed', () => {
+      const now = Date.now()
+      localStorage.setItem('lists', JSON.stringify([
+        { id: 'a', n: 'L', i: [item('stale', now - 91 * DAY, 1)] }
+      ]))
+      localStorage.setItem('syncMeta', JSON.stringify({
+        a: { authToken: 't', role: 'editor', lastCursor: now - 95 * DAY }
+      }))
+      const store = useListsStore()
+      store.init()
+      expect(store.lists[0].i.map(i => i.id)).toEqual(['stale'])
+    })
+
+    it('init prunes a stale tombstone the sync cursor has passed', () => {
+      const now = Date.now()
+      localStorage.setItem('lists', JSON.stringify([
+        { id: 'a', n: 'L', i: [item('stale', now - 91 * DAY, 1)] }
+      ]))
+      localStorage.setItem('syncMeta', JSON.stringify({
+        a: { authToken: 't', role: 'editor', lastCursor: now - DAY }
+      }))
+      const store = useListsStore()
+      store.init()
+      expect(store.lists[0].i).toEqual([])
+    })
+  })
+
   it('createList appends a list and persists', () => {
     const store = useListsStore()
     store.createList(new List('Groceries', []))


### PR DESCRIPTION
## Summary
Soft-deleted items (`d = 1`) were kept in localStorage indefinitely — `mergeList` never pruned them and `src/stores/lists.ts` had no local GC. The server already GCs tombstones (`.github/workflows/gc-tombstones.yml`); the client had no equivalent, so for long-lived shared lists the `lists` key grew unbounded.

`init` now prunes tombstones once they are older than the server's 90-day GC window. For a synced list the tombstone must additionally sit at or below `lastCursor` — i.e. this client has already polled past it — so a not-yet-synced local delete is never dropped before the server has seen it.

## Testing
- `npm run test:unit` — 238 passed (5 new tests covering stale/recent tombstones, active items, persistence, and the synced-cursor guard)
- `npm run type-check` — clean

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)