### PR TITLE
fix(theme): swallow localStorage quota errors in setMode

### DIFF
--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -22,7 +22,11 @@ function onMediaChange (e: MediaQueryListEvent) {
 
 function setMode (m: ThemeMode) {
   mode.value = m
-  localStorage.setItem(STORAGE_KEY, m)
+  try {
+    localStorage.setItem(STORAGE_KEY, m)
+  } catch (err) {
+    console.warn('[useTheme] failed to persist mode', err)
+  }
   apply(m)
 }
 

--- a/tests/unit/composables/useTheme.spec.ts
+++ b/tests/unit/composables/useTheme.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 let mockMatches = false
 const mockAddEventListener = vi.fn()
@@ -28,6 +28,10 @@ describe('useTheme', () => {
     mockMatches = false
     mockAddEventListener.mockClear()
     mockRemoveEventListener.mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   describe('init', () => {
@@ -113,6 +117,17 @@ describe('useTheme', () => {
       setMode('dark')
       expect(mode.value).toBe('dark')
       expect(localStorage.getItem('theme-mode')).toBe('dark')
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+    })
+
+    it('still applies the mode when localStorage write throws (quota)', async () => {
+      const { mode, setMode, init } = await freshTheme()
+      init()
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new DOMException('quota', 'QuotaExceededError')
+      })
+      expect(() => setMode('dark')).not.toThrow()
+      expect(mode.value).toBe('dark')
       expect(document.documentElement.classList.contains('dark')).toBe(true)
     })
 


### PR DESCRIPTION
## Summary
- `useTheme.setMode` wraps `localStorage.setItem` in try/catch so a full storage quota no longer prevents the new mode from being applied to the DOM.
- Adds a regression test that throws a `QuotaExceededError` from the mocked `setItem` and asserts the mode is still applied.

Closes #185

## Test plan
- [x] `npx vitest run tests/unit/composables/useTheme.spec.ts` — all 16 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)