### PR TITLE
fix(sync): dedup 401/404 toast via shared onAuthLost helper

### DIFF
--- a/src/sync/cleanup.ts
+++ b/src/sync/cleanup.ts
@@ -1,5 +1,6 @@
 import { getMeta, removeMeta } from './storage'
 import { useListsStore } from '@/stores/lists'
+import { useToastStore } from '@/stores/toast'
 
 // Removes syncMeta and deletes the list from the local store.
 // Does NOT stop the poller or touch pendingOps — callers handle those.
@@ -7,4 +8,19 @@ export function cleanupListLocally (listId: string): void {
   if (!getMeta(listId)) return
   removeMeta(listId)
   useListsStore().deleteList(listId)
+}
+
+// Shared handler for 401/404 surfaced by poll or queue. The getMeta gate
+// dedupes — whichever caller arrives second sees no meta and stays silent,
+// so the user gets one toast instead of two.
+export function onAuthLost (listId: string, kind: 'unauthorized' | 'not-found'): void {
+  if (!getMeta(listId)) return
+  const listName = useListsStore().getListFromId(listId)?.n ?? 'a shared list'
+  useToastStore().add(
+    kind === 'unauthorized'
+      ? `Access to "${listName}" was revoked.`
+      : `"${listName}" was deleted.`,
+    'error'
+  )
+  cleanupListLocally(listId)
 }

--- a/src/sync/poll.ts
+++ b/src/sync/poll.ts
@@ -1,9 +1,8 @@
 import { pollList } from './transport'
 import { applyPollPayload } from './reconcile'
 import { getMeta, getSyncMetaMap, saveSyncMetaMap } from './storage'
-import { cleanupListLocally } from './cleanup'
+import { onAuthLost } from './cleanup'
 import { useListsStore } from '@/stores/lists'
-import { useToastStore } from '@/stores/toast'
 
 const POLL_INTERVAL_MS = 5_000
 const MAX_BACKOFF_MS = 60_000
@@ -83,15 +82,8 @@ async function runPoller (listId: string, state: PollState): Promise<void> {
       useListsStore().gcTombstones()
       await sleep(POLL_INTERVAL_MS)
     } else if (result.error.kind === 'unauthorized' || result.error.kind === 'not-found') {
-      const listName = useListsStore().getListFromId(listId)?.n ?? 'a shared list'
-      useToastStore().add(
-        result.error.kind === 'unauthorized'
-          ? `Access to "${listName}" was revoked.`
-          : `"${listName}" was deleted.`,
-        'error'
-      )
       stopPoller(listId)
-      cleanupListLocally(listId)
+      onAuthLost(listId, result.error.kind)
       break
     } else {
       await sleep(state.backoff)

--- a/src/sync/queue.ts
+++ b/src/sync/queue.ts
@@ -1,9 +1,8 @@
-import { useListsStore } from '@/stores/lists'
 import { useToastStore } from '@/stores/toast'
 import { getMeta } from './storage'
 import { upsertItem } from './transport'
 import { reconcileServerItem } from './reconcile'
-import { cleanupListLocally } from './cleanup'
+import { onAuthLost } from './cleanup'
 import type { Op, UpsertItemOp } from './types'
 
 const QUEUE_KEY = 'pendingOps'
@@ -129,15 +128,8 @@ async function flush (): Promise<void> {
       result.error.kind === 'unauthorized' ||
       result.error.kind === 'not-found'
     ) {
-      const listName = useListsStore().getListFromId(op.listId)?.n ?? 'a shared list'
-      useToastStore().add(
-        result.error.kind === 'unauthorized'
-          ? `Access to "${listName}" was revoked.`
-          : `"${listName}" was deleted.`,
-        'error'
-      )
       purgeOpsForList(op.listId)
-      cleanupListLocally(op.listId)
+      onAuthLost(op.listId, result.error.kind)
     } else if (
       result.error.kind === 'server' &&
       result.error.status >= 400 &&

--- a/tests/unit/sync/cleanup.spec.ts
+++ b/tests/unit/sync/cleanup.spec.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
-import { cleanupListLocally } from '@/sync/cleanup'
+import { cleanupListLocally, onAuthLost } from '@/sync/cleanup'
 import { getMeta, setMeta } from '@/sync/storage'
 import { useListsStore } from '@/stores/lists'
+import { useToastStore } from '@/stores/toast'
 
 vi.mock('@/sync/poll', () => ({ stopPoller: vi.fn() }))
 
@@ -41,5 +42,57 @@ describe('cleanupListLocally', () => {
 
     expect(getMeta('list1')).toBeNull()
     expect(store.lists).toHaveLength(0)
+  })
+})
+
+describe('onAuthLost', () => {
+  it('toasts the revoke message and cleans up when meta exists (unauthorized)', () => {
+    const store = useListsStore()
+    store.$patch({ lists: [{ id: 'list1', n: 'My List', i: [] }] })
+    setMeta('list1', { authToken: 'tok', role: 'editor', lastCursor: 1 })
+    const toast = useToastStore()
+
+    onAuthLost('list1', 'unauthorized')
+
+    expect(toast.toasts).toHaveLength(1)
+    expect(toast.toasts[0].message).toContain('revoked')
+    expect(toast.toasts[0].message).toContain('"My List"')
+    expect(getMeta('list1')).toBeNull()
+    expect(store.lists).toHaveLength(0)
+  })
+
+  it('toasts the deleted message and cleans up when meta exists (not-found)', () => {
+    const store = useListsStore()
+    store.$patch({ lists: [{ id: 'list1', n: 'My List', i: [] }] })
+    setMeta('list1', { authToken: 'tok', role: 'editor', lastCursor: 1 })
+    const toast = useToastStore()
+
+    onAuthLost('list1', 'not-found')
+
+    expect(toast.toasts).toHaveLength(1)
+    expect(toast.toasts[0].message).toContain('deleted')
+  })
+
+  it('is a no-op when meta is absent (dedup guard)', () => {
+    const store = useListsStore()
+    store.$patch({ lists: [] })
+    const toast = useToastStore()
+
+    onAuthLost('list1', 'unauthorized')
+
+    expect(toast.toasts).toHaveLength(0)
+    expect(store.lists).toHaveLength(0)
+  })
+
+  it('emits only one toast when called twice — second call sees no meta', () => {
+    const store = useListsStore()
+    store.$patch({ lists: [{ id: 'list1', n: 'My List', i: [] }] })
+    setMeta('list1', { authToken: 'tok', role: 'editor', lastCursor: 1 })
+    const toast = useToastStore()
+
+    onAuthLost('list1', 'unauthorized')
+    onAuthLost('list1', 'unauthorized')
+
+    expect(toast.toasts).toHaveLength(1)
   })
 })

--- a/tests/unit/sync/poll.spec.ts
+++ b/tests/unit/sync/poll.spec.ts
@@ -3,6 +3,7 @@ import { startPoller, stopPoller } from '@/sync/poll'
 import { pollList } from '@/sync/transport'
 import { applyPollPayload } from '@/sync/reconcile'
 import { getMeta, getSyncMetaMap, saveSyncMetaMap } from '@/sync/storage'
+import { onAuthLost } from '@/sync/cleanup'
 
 vi.mock('@/sync/transport', () => ({ pollList: vi.fn() }))
 vi.mock('@/sync/reconcile', () => ({ applyPollPayload: vi.fn() }))
@@ -11,10 +12,9 @@ vi.mock('@/sync/storage', () => ({
   getSyncMetaMap: vi.fn(() => ({})),
   saveSyncMetaMap: vi.fn()
 }))
-vi.mock('@/sync/cleanup', () => ({ cleanupListLocally: vi.fn() }))
+vi.mock('@/sync/cleanup', () => ({ cleanupListLocally: vi.fn(), onAuthLost: vi.fn() }))
 const mGcTombstones = vi.fn()
 vi.mock('@/stores/lists', () => ({ useListsStore: vi.fn(() => ({ getListFromId: vi.fn(() => ({ n: 'Test List' })), gcTombstones: mGcTombstones })) }))
-vi.mock('@/stores/toast', () => ({ useToastStore: vi.fn(() => ({ add: vi.fn() })) }))
 
 const mGetMeta = vi.mocked(getMeta)
 const mPollList = vi.mocked(pollList)
@@ -95,7 +95,7 @@ describe('sync/poll', () => {
     )
   })
 
-  it('runPoller: stops and removes itself on unauthorized error', async () => {
+  it('runPoller: stops and delegates to onAuthLost on unauthorized error', async () => {
     mGetMeta.mockReturnValue({ authToken: 'bad', lastCursor: 0, role: 'editor' })
     mPollList.mockResolvedValue({ ok: false, error: { kind: 'unauthorized' } })
 
@@ -103,13 +103,14 @@ describe('sync/poll', () => {
     await vi.runAllTimersAsync()
 
     expect(mPollList).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(onAuthLost)).toHaveBeenCalledWith('unauth1', 'unauthorized')
     mGetMeta.mockReturnValue(null)
     startPoller('unauth1')
     await vi.runAllTimersAsync()
     expect(mPollList).toHaveBeenCalledTimes(1)
   })
 
-  it('runPoller: stops on not-found error', async () => {
+  it('runPoller: stops and delegates to onAuthLost on not-found error', async () => {
     mGetMeta.mockReturnValue({ authToken: 'tok', lastCursor: 0, role: 'owner' })
     mPollList.mockResolvedValue({ ok: false, error: { kind: 'not-found' } })
 
@@ -118,6 +119,7 @@ describe('sync/poll', () => {
 
     expect(mPollList).toHaveBeenCalledTimes(1)
     expect(vi.mocked(applyPollPayload)).not.toHaveBeenCalled()
+    expect(vi.mocked(onAuthLost)).toHaveBeenCalledWith('notfound1', 'not-found')
   })
 
   it('stopPoller: removes the visibilitychange listener registered while hidden', async () => {

--- a/tests/unit/sync/queue.spec.ts
+++ b/tests/unit/sync/queue.spec.ts
@@ -3,7 +3,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { getMeta } from '@/sync/storage'
 import { upsertItem } from '@/sync/transport'
 import { reconcileServerItem } from '@/sync/reconcile'
-import { cleanupListLocally } from '@/sync/cleanup'
+import { onAuthLost } from '@/sync/cleanup'
 import { useListsStore } from '@/stores/lists'
 import { useToastStore } from '@/stores/toast'
 import { enqueue, startDrainer, _resetForTest } from '@/sync/queue'
@@ -26,7 +26,8 @@ vi.mock('@/sync/poll', () => ({
 }))
 
 vi.mock('@/sync/cleanup', () => ({
-  cleanupListLocally: vi.fn()
+  cleanupListLocally: vi.fn(),
+  onAuthLost: vi.fn()
 }))
 
 vi.mock('@/stores/lists', () => ({
@@ -192,34 +193,28 @@ describe('flush — missing meta', () => {
 })
 
 describe('flush — 401/404 teardown', () => {
-  it('tears down on 401: calls cleanupListLocally and shows revoke toast', async () => {
+  it('purges ops and delegates to onAuthLost on 401', async () => {
     vi.mocked(getMeta).mockReturnValue(META)
     vi.mocked(upsertItem).mockResolvedValue({ ok: false, error: { kind: 'unauthorized' } })
     mockStore()
-    const toastAdd = vi.fn()
-    vi.mocked(useToastStore).mockReturnValue({ add: toastAdd } as unknown as ReturnType<typeof useToastStore>)
 
     enqueue({ kind: 'upsertItem', listId: 'list1', item: ITEM })
     await vi.runAllTimersAsync()
 
-    expect(vi.mocked(cleanupListLocally)).toHaveBeenCalledWith('list1')
-    expect(toastAdd).toHaveBeenCalledWith(expect.stringContaining('revoked'), 'error')
+    expect(vi.mocked(onAuthLost)).toHaveBeenCalledWith('list1', 'unauthorized')
     const q = JSON.parse(localStorage.getItem('pendingOps') ?? '[]') as unknown[]
     expect(q).toHaveLength(0)
   })
 
-  it('tears down on 404: calls cleanupListLocally and shows deleted toast', async () => {
+  it('purges ops and delegates to onAuthLost on 404', async () => {
     vi.mocked(getMeta).mockReturnValue(META)
     vi.mocked(upsertItem).mockResolvedValue({ ok: false, error: { kind: 'not-found' } })
     mockStore()
-    const toastAdd = vi.fn()
-    vi.mocked(useToastStore).mockReturnValue({ add: toastAdd } as unknown as ReturnType<typeof useToastStore>)
 
     enqueue({ kind: 'upsertItem', listId: 'list1', item: ITEM })
     await vi.runAllTimersAsync()
 
-    expect(vi.mocked(cleanupListLocally)).toHaveBeenCalledWith('list1')
-    expect(toastAdd).toHaveBeenCalledWith(expect.stringContaining('deleted'), 'error')
+    expect(vi.mocked(onAuthLost)).toHaveBeenCalledWith('list1', 'not-found')
   })
 
   it('drops only the affected list ops, leaves other lists intact', async () => {


### PR DESCRIPTION
## Summary
- Extracts `onAuthLost(listId, kind)` in `src/sync/cleanup.ts`. Guarded by `getMeta` so the second caller sees no meta and stays silent.
- `poll.ts` and `queue.ts` no longer build their own toast strings — both call the helper.
- Unit tests cover the dedup guard, both messages, and the new poll/queue delegation paths.

Closes #184

## Test plan
- [x] `npx vitest run` — all 242 tests pass.
- [x] `npx vue-tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)