### PR TITLE
fix(sync): drop ops on any 4xx instead of retrying forever

### DIFF
--- a/src/sync/queue.ts
+++ b/src/sync/queue.ts
@@ -138,6 +138,18 @@ async function flush (): Promise<void> {
       )
       purgeOpsForList(op.listId)
       cleanupListLocally(op.listId)
+    } else if (
+      result.error.kind === 'server' &&
+      result.error.status >= 400 &&
+      result.error.status < 500
+    ) {
+      // Any other 4xx — 400 (invalid), 403 (forbidden), 413 (too large) —
+      // is terminal for this op. Retrying never recovers, and the head op
+      // would block every subsequent change on every list until the user
+      // restarts and manually clears pendingOps.
+      useToastStore().add('Could not save change — the server rejected it.', 'error')
+      removeOpById(op.opId)
+      backoffMs = 1_000
     } else {
       await sleep(backoffMs)
       backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS)

--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -13,7 +13,7 @@
 
     <form class="new-item" @submit.prevent="addItemToList">
       <label for="name" class="sr-only">Item Name</label>
-      <input v-model="name" required
+      <input v-model="name" required maxlength="500"
              class="new-item__input"
              ref="itemName"
              type="text" id="name" placeholder="Item Name"/>
@@ -121,11 +121,12 @@ function onListDeleted () {
 }
 
 function addItemToList (): void {
-  const addedName = name.value!
-  listsStore.addItem(listId.value, new Item(addedName, String(quantity.value)))
+  const trimmed = (name.value ?? '').trim()
+  if (trimmed === '') return
+  listsStore.addItem(listId.value, new Item(trimmed, String(quantity.value)))
   name.value = null
   quantity.value = 1
-  announce(`${addedName} added`)
+  announce(`${trimmed} added`)
   itemName.value!.focus()
 }
 

--- a/tests/unit/sync/queue.spec.ts
+++ b/tests/unit/sync/queue.spec.ts
@@ -236,6 +236,55 @@ describe('flush — 401/404 teardown', () => {
   })
 })
 
+describe('flush — generic 4xx', () => {
+  it('drops the op and toasts on 400 instead of retrying forever', async () => {
+    vi.mocked(getMeta).mockReturnValue(META)
+    vi.mocked(upsertItem).mockResolvedValue({ ok: false, error: { kind: 'server', status: 400 } })
+    mockStore({ getListFromId: vi.fn().mockReturnValue({ id: 'list1', n: 'G', i: [] }) })
+    const toastAdd = vi.fn()
+    vi.mocked(useToastStore).mockReturnValue({ add: toastAdd } as unknown as ReturnType<typeof useToastStore>)
+
+    enqueue({ kind: 'upsertItem', listId: 'list1', item: ITEM })
+    await vi.runAllTimersAsync()
+
+    expect(vi.mocked(upsertItem)).toHaveBeenCalledTimes(1)
+    expect(toastAdd).toHaveBeenCalledWith(expect.stringContaining('Could not save'), 'error')
+    const q = JSON.parse(localStorage.getItem('pendingOps') ?? '[]') as unknown[]
+    expect(q).toHaveLength(0)
+  })
+
+  it('drops the op on 413 (too large) and keeps draining the rest', async () => {
+    vi.mocked(getMeta).mockReturnValue(META)
+    vi.mocked(upsertItem)
+      .mockResolvedValueOnce({ ok: false, error: { kind: 'server', status: 413 } })
+      .mockResolvedValue({ ok: true, data: { item: ITEM } })
+    mockStore({ getListFromId: vi.fn().mockReturnValue({ id: 'list1', n: 'G', i: [] }) })
+
+    enqueue({ kind: 'upsertItem', listId: 'list1', item: { ...ITEM, id: 'reject' } })
+    enqueue({ kind: 'upsertItem', listId: 'list1', item: { ...ITEM, id: 'ok' } })
+    await vi.runAllTimersAsync()
+
+    expect(vi.mocked(upsertItem)).toHaveBeenCalledTimes(2)
+    const q = JSON.parse(localStorage.getItem('pendingOps') ?? '[]') as unknown[]
+    expect(q).toHaveLength(0)
+  })
+
+  it('still retries on 5xx (server) instead of dropping', async () => {
+    vi.mocked(getMeta).mockReturnValue(META)
+    vi.mocked(upsertItem)
+      .mockResolvedValueOnce({ ok: false, error: { kind: 'server', status: 500 } })
+      .mockResolvedValue({ ok: true, data: { item: ITEM } })
+    mockStore({ getListFromId: vi.fn().mockReturnValue({ id: 'list1', n: 'G', i: [] }) })
+
+    enqueue({ kind: 'upsertItem', listId: 'list1', item: ITEM })
+    await vi.runAllTimersAsync()
+
+    expect(vi.mocked(upsertItem)).toHaveBeenCalledTimes(2)
+    const q = JSON.parse(localStorage.getItem('pendingOps') ?? '[]') as unknown[]
+    expect(q).toHaveLength(0)
+  })
+})
+
 describe('flush — network backoff', () => {
   it('retries after sleep on network error then succeeds', async () => {
     vi.mocked(getMeta).mockReturnValue(META)

--- a/tests/unit/views/List.spec.ts
+++ b/tests/unit/views/List.spec.ts
@@ -104,6 +104,21 @@ describe('List.vue', () => {
     expect(store.lists[0].i[0].n).toBe('Milk')
   })
 
+  it('does not add an item when the name is whitespace-only', async () => {
+    const { wrapper, store } = await mountList([])
+    await wrapper.find('input#name').setValue('   ')
+    await wrapper.find('input#quantity').setValue('3')
+    await wrapper.find('form').trigger('submit')
+    expect(store.lists[0].i).toHaveLength(0)
+  })
+
+  it('trims surrounding whitespace from the new item name on add', async () => {
+    const { wrapper, store } = await mountList([])
+    await wrapper.find('input#name').setValue('  Milk  ')
+    await wrapper.find('form').trigger('submit')
+    expect(store.lists[0].i[0].n).toBe('Milk')
+  })
+
   it('toggles an item to checked on checkbox input', async () => {
     const { wrapper, store } = await mountList()
     await wrapper.find('input[type="checkbox"]').trigger('input')


### PR DESCRIPTION
## Summary
- Queue's flush loop now treats any 400-499 server response as terminal: drop the op and toast. Previously only 401/404 cleared and every other 4xx (400 invalid, 403, 413) wedged the queue head forever, blocking every later op on every list until app restart + manual localStorage clear.
- Adds `maxlength=500` + whitespace trim / empty rejection on the new-item form in `List.vue` so a user typing only spaces or pasting an oversized name can no longer organically trigger the 400 path.
- New vitest cases cover the 400 + 413 drop and confirm 5xx still retries.

Closes #179

## Test plan
- [x] `npx vitest run` — all 243 tests pass.
- [x] `npx vue-tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)