### PR TITLE
fix(sync): GC tombstones after every successful poll

### DIFF
--- a/src/sync/poll.ts
+++ b/src/sync/poll.ts
@@ -77,6 +77,10 @@ async function runPoller (listId: string, state: PollState): Promise<void> {
         map[listId].lastCursor = result.data.cursor
         saveSyncMetaMap(map)
       }
+      // Long-lived PWA tabs can run for weeks without a cold start, so the
+      // store.init() GC never re-runs. Piggyback on the poll's settle moment
+      // to prune expired tombstones (cheap; LWW dedup keeps it idempotent).
+      useListsStore().gcTombstones()
       await sleep(POLL_INTERVAL_MS)
     } else if (result.error.kind === 'unauthorized' || result.error.kind === 'not-found') {
       const listName = useListsStore().getListFromId(listId)?.n ?? 'a shared list'

--- a/tests/unit/sync/poll.spec.ts
+++ b/tests/unit/sync/poll.spec.ts
@@ -12,7 +12,8 @@ vi.mock('@/sync/storage', () => ({
   saveSyncMetaMap: vi.fn()
 }))
 vi.mock('@/sync/cleanup', () => ({ cleanupListLocally: vi.fn() }))
-vi.mock('@/stores/lists', () => ({ useListsStore: vi.fn(() => ({ getListFromId: vi.fn(() => ({ n: 'Test List' })) })) }))
+const mGcTombstones = vi.fn()
+vi.mock('@/stores/lists', () => ({ useListsStore: vi.fn(() => ({ getListFromId: vi.fn(() => ({ n: 'Test List' })), gcTombstones: mGcTombstones })) }))
 vi.mock('@/stores/toast', () => ({ useToastStore: vi.fn(() => ({ add: vi.fn() })) }))
 
 const mGetMeta = vi.mocked(getMeta)
@@ -50,6 +51,30 @@ describe('sync/poll', () => {
     startPoller('nometa1')
     await vi.runAllTimersAsync()
     expect(mPollList).not.toHaveBeenCalled()
+  })
+
+  it('runPoller: invokes gcTombstones after a successful poll', async () => {
+    mGetMeta
+      .mockReturnValueOnce({ authToken: 'tok', lastCursor: 0, role: 'owner' })
+      .mockReturnValue(null)
+    mPollList.mockResolvedValue({ ok: true, data: { cursor: 1, items: [] } })
+
+    startPoller('gc1')
+    await vi.runAllTimersAsync()
+
+    expect(mGcTombstones).toHaveBeenCalled()
+  })
+
+  it('runPoller: does NOT invoke gcTombstones when poll fails (network)', async () => {
+    mGetMeta
+      .mockReturnValueOnce({ authToken: 'tok', lastCursor: 0, role: 'owner' })
+      .mockReturnValue(null)
+    mPollList.mockResolvedValue({ ok: false, error: { kind: 'network' } })
+
+    startPoller('gc2')
+    await vi.runAllTimersAsync()
+
+    expect(mGcTombstones).not.toHaveBeenCalled()
   })
 
   it('runPoller: calls pollList, applyPollPayload, and stores returned cursor on success', async () => {


### PR DESCRIPTION
## Summary
- `useListsStore().gcTombstones()` now runs after each successful poll, so expired tombstones get pruned in long-lived PWA tabs that never see a fresh `init()`.
- Cost is O(lists × items) per call, dominated by a couple of comparisons per item — fine for the typical workload.
- LWW dedup means repeated calls are idempotent; no risk of pruning local-only edits that haven't synced.
- Test asserts gcTombstones is invoked on success and skipped on a failed poll.

Closes #180

## Test plan
- [x] `npx vitest run` — all 240 tests pass.
- [x] `npx vue-tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)