### PR TITLE
fix(list): guard against missing list to prevent TypeError

### DIFF
--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -100,7 +100,7 @@ const provisioning = ref(false)
 
 watch([list, shareOpen, provisioning], ([currentList, isOpen, isProvisioning]) => {
   if (!currentList && !isOpen && !isProvisioning) router.replace({ name: 'Lists' })
-})
+}, { immediate: true })
 
 function openShare () {
   if (list.value) {
@@ -130,7 +130,7 @@ function addItemToList (): void {
 }
 
 function modifyItemQuantity (input: HTMLInputElement, id: string): void {
-  const item = list.value!.i.find(i => i.id === id)
+  const item = list.value?.i.find(i => i.id === id)
   if (!item) return
   const trimmed = input.value.trim()
   if (trimmed !== '' && !isNaN(Number(trimmed))) {
@@ -141,7 +141,7 @@ function modifyItemQuantity (input: HTMLInputElement, id: string): void {
 }
 
 function modifyItemName (input: HTMLInputElement, id: string): void {
-  const item = list.value!.i.find(i => i.id === id)
+  const item = list.value?.i.find(i => i.id === id)
   if (!item) return
   const trimmed = input.value.trim()
   if (trimmed !== '') {
@@ -153,7 +153,7 @@ function modifyItemName (input: HTMLInputElement, id: string): void {
 }
 
 async function deleteItem (id: string): Promise<void> {
-  const item = list.value!.i.find(i => i.id === id)
+  const item = list.value?.i.find(i => i.id === id)
   if (!item) return
   const deletedName = item.n
 
@@ -173,7 +173,7 @@ async function deleteItem (id: string): Promise<void> {
 }
 
 function toggleItemCheckedStatus (id: string): void {
-  const item = list.value!.i.find(i => i.id === id)
+  const item = list.value?.i.find(i => i.id === id)
   if (!item) return
   const next = item.c === 0 ? 1 : 0
   listsStore.updateItem(listId.value, id, { c: next })
@@ -181,7 +181,10 @@ function toggleItemCheckedStatus (id: string): void {
 }
 
 onMounted(async () => {
-  document.title = list.value!.n + ' List | Groceries List'
+  // The redirect watch above fires async — guard the sync path so a stale
+  // tab or hand-typed URL doesn't throw before the watch can route away.
+  if (!list.value) return
+  document.title = list.value.n + ' List | Groceries List'
   await nextTick()
   itemName.value?.focus()
 })

--- a/tests/unit/views/List.spec.ts
+++ b/tests/unit/views/List.spec.ts
@@ -205,6 +205,39 @@ describe('List.vue', () => {
     })
   })
 
+  describe('crash safety when list is missing', () => {
+    // Mounts on a route whose id doesn't exist in the store.
+    const mountUnknown = async () => {
+      const pinia = createPinia()
+      const router = createRouter({ history: createMemoryHistory(), routes })
+      await router.push({ name: 'List', params: { id: 'ghost' } })
+
+      const wrapper = mount(ListV, {
+        global: {
+          plugins: [pinia, router],
+          stubs: { FontAwesomeIcon: { template: '<span />' } }
+        }
+      })
+      await nextTick()
+      return { wrapper, router }
+    }
+
+    it('does not throw when mounted with an unknown route id', async () => {
+      let result: { wrapper: ReturnType<typeof mount>; router: ReturnType<typeof createRouter> } | null = null
+      await expect(async () => { result = await mountUnknown() }).not.toThrow()
+      await flushPromises()
+      expect(result!.router.currentRoute.value.name).toBe('Lists')
+    })
+
+    it('does not crash when the list is removed mid-edit', async () => {
+      const { wrapper, store } = await mountList()
+      // Simulate the list disappearing while a handler is mid-flight.
+      store.$patch({ lists: [] })
+      const qtyInput = wrapper.find('.item__quantity__input')
+      expect(() => qtyInput.element.dispatchEvent(new Event('change'))).not.toThrow()
+    })
+  })
+
   describe('navigation guard', () => {
     it('does NOT navigate to Lists when the share button is clicked', async () => {
       const { wrapper, router } = await mountListWithSheet()


### PR DESCRIPTION
## Summary
- Replaced non-null assertions on `list.value` in `onMounted` and the item handlers (modify name/qty, toggle, delete, mount title) with optional chaining + early return so a stale route id no longer throws.
- Made the redirect watch `immediate: true` so a hand-typed unknown URL routes to `Lists` on mount instead of rendering blank.
- Tests cover mount with an unknown route id and a mid-edit removal racing a change event.

Closes #178

## Test plan
- [x] `npx vitest run` — all 240 tests pass.
- [x] `npx vue-tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)