### PR TITLE
fix(api): reject owner tokens at /join

### DIFF
--- a/functions/api/_shared/handlers.ts
+++ b/functions/api/_shared/handlers.ts
@@ -154,7 +154,12 @@ export async function handleJoin (
     'SELECT list_id, role, revoked_at FROM list_tokens WHERE token_hash = ? AND list_id = ?'
   ).bind(hash, listId).first<TokenRow>()
 
-  if (!tokenRow || tokenRow.revoked_at != null) {
+  // Owner tokens are bound to the provisioning device and are NOT shareable
+  // — reject them at /join even though the row would otherwise be valid.
+  // Mismatched roles would otherwise let an "editor" client wield owner
+  // privileges (mint, revoke, delete) because subsequent endpoints re-check
+  // the token's role server-side from the same row.
+  if (!tokenRow || tokenRow.revoked_at != null || tokenRow.role !== ROLES.editor) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 })
   }
 

--- a/tests/integration/api/lists.spec.ts
+++ b/tests/integration/api/lists.spec.ts
@@ -108,10 +108,16 @@ describe('POST /api/lists', () => {
     expect(res.status).toBe(200)
     const { id, authToken } = await res.json() as { id: string; authToken: string }
 
+    const mintReq = new Request(`http://localhost/api/lists/${id}/tokens`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${authToken}` }
+    })
+    const { token: editorToken } = await handleMintToken(db, mintReq, id).then(r => r.json() as Promise<{ token: string }>)
+
     const joinReq = new Request(`http://localhost/api/lists/${id}/join`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ token: authToken })
+      body: JSON.stringify({ token: editorToken })
     })
     const body = await handleJoin(db, joinReq, id).then(r => r.json() as Promise<{ name: string }>)
     expect(body.name).toBe('Weekly Shop')
@@ -199,13 +205,24 @@ describe('POST /api/lists/:id/join', () => {
     return res.json() as Promise<{ id: string; authToken: string }>
   }
 
-  it('returns list data for a valid token', async () => {
+  async function mintEditorToken (id: string, ownerToken: string) {
+    const mintReq = new Request(`http://localhost/api/lists/${id}/tokens`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${ownerToken}` }
+    })
+    const res = await handleMintToken(db, mintReq, id)
+    const body = await res.json() as { token: string }
+    return body.token
+  }
+
+  it('returns list data for a valid editor token', async () => {
     const { id, authToken } = await provision('Test List')
+    const editorToken = await mintEditorToken(id, authToken)
 
     const req = new Request(`http://localhost/api/lists/${id}/join`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ token: authToken })
+      body: JSON.stringify({ token: editorToken })
     })
     const res = await handleJoin(db, req, id)
     expect(res.status).toBe(200)
@@ -217,18 +234,31 @@ describe('POST /api/lists/:id/join', () => {
     expect(body.items).toEqual([])
   })
 
-  it('is multi-use — same token can join multiple times', async () => {
+  it('is multi-use — same editor token can join multiple times', async () => {
     const { id, authToken } = await provision()
+    const editorToken = await mintEditorToken(id, authToken)
 
     for (let i = 0; i < 3; i++) {
       const req = new Request(`http://localhost/api/lists/${id}/join`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token: authToken })
+        body: JSON.stringify({ token: editorToken })
       })
       const res = await handleJoin(db, req, id)
       expect(res.status).toBe(200)
     }
+  })
+
+  it('rejects an owner token with 401 — owner tokens are not shareable', async () => {
+    const { id, authToken } = await provision()
+
+    const req = new Request(`http://localhost/api/lists/${id}/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: authToken })
+    })
+    const res = await handleJoin(db, req, id)
+    expect(res.status).toBe(401)
   })
 
   it('returns 401 for an invalid token', async () => {
@@ -257,6 +287,7 @@ describe('POST /api/lists/:id/join', () => {
 
   it('does not return soft-deleted items in the join payload', async () => {
     const { id, authToken } = await provision()
+    const editorToken = await mintEditorToken(id, authToken)
     const upsertReq = (itemId: string, item: object) => new Request(`http://localhost/api/lists/${id}/items/${itemId}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` },
@@ -269,7 +300,7 @@ describe('POST /api/lists/:id/join', () => {
     const req = new Request(`http://localhost/api/lists/${id}/join`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ token: authToken })
+      body: JSON.stringify({ token: editorToken })
     })
     const res = await handleJoin(db, req, id)
     const body = await res.json() as { items: Array<{ id: string }>, cursor: number }
@@ -279,14 +310,15 @@ describe('POST /api/lists/:id/join', () => {
     expect(body.cursor).toBe(2000)
   })
 
-  it('returns 401 when token belongs to a different list', async () => {
-    const { authToken } = await provision('List A')
+  it('returns 401 when editor token belongs to a different list', async () => {
+    const { id: idA, authToken: ownerA } = await provision('List A')
+    const editorA = await mintEditorToken(idA, ownerA)
     const { id: otherId } = await provision('List B')
 
     const req = new Request(`http://localhost/api/lists/${otherId}/join`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ token: authToken })
+      body: JSON.stringify({ token: editorA })
     })
     const res = await handleJoin(db, req, otherId)
     expect(res.status).toBe(401)


### PR DESCRIPTION
## Summary
- `handleJoin` previously hardcoded `role: editor` in the response but later endpoints rechecked role from the same token row. An owner token presented to `/join` produced an "editor" client wielding owner privileges (mint, revoke, delete).
- The handler now rejects any token whose row is not `editor` with 401, in addition to the existing revocation check. Owner tokens are bound to the provisioning device and were never meant to be shareable.
- Integration tests updated to mint an editor token before calling `/join`. New test asserts owner-token presentation returns 401.

Closes #183

## Test plan
- [x] `npm run test:integration` — 49/49 pass.
- [x] `npx vitest run` — 238/238 pass.
- [x] `npx vue-tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)