### PR TITLE
fix(join): re-join when stored token differs from link's token

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -49,7 +49,12 @@ async function handleJoinFragment () {
 
   const [, listId, token] = m
 
-  if (sync.getMeta(listId)) {
+  // Stale local meta (e.g. owner rotated the editor token) would otherwise
+  // short-circuit the rejoin — the poller keeps presenting the dead token,
+  // 401s eventually, and the user sees a confusing "Access revoked" toast.
+  // Fall through to the full join flow whenever the link's token differs.
+  const existing = sync.getMeta(listId)
+  if (existing && existing.authToken === token) {
     router.replace({ name: 'List', params: { id: listId } })
     return
   }

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -56,6 +56,12 @@ export async function provision (
 export type JoinResult = { ok: true } | { ok: false; reason: 'network' | 'invalid' }
 
 export async function join (listId: string, token: string): Promise<JoinResult> {
+  // Halt any prior poller bound to a stale auth token. Without this, an
+  // in-flight pollList() with the old token can 401 after we've already
+  // setMeta() with the new one — the poll's stopped-state check then
+  // discards that result before the auth-lost path can delete the list.
+  stopPoller(listId)
+
   const result = await joinList(listId, token)
   if (!result.ok) {
     return { ok: false, reason: result.error.kind === 'network' ? 'network' : 'invalid' }

--- a/tests/unit/AppJoin.spec.ts
+++ b/tests/unit/AppJoin.spec.ts
@@ -64,12 +64,22 @@ describe('App.vue — handleJoinFragment', () => {
     expect(router.currentRoute.value.params.id).toBe('listid123')
   })
 
-  it('navigates without calling join when list is already synced', async () => {
-    vi.mocked(sync.getMeta).mockReturnValue({ authToken: 'tok', role: 'owner', lastCursor: 1 })
+  it('navigates without calling join when list is already synced with the same token', async () => {
+    vi.mocked(sync.getMeta).mockReturnValue({ authToken: 'tokenxyz', role: 'editor', lastCursor: 1 })
     window.location.hash = '#join=listid123.tokenxyz'
     const router = makeRouter()
     await mountApp(router)
     expect(sync.join).not.toHaveBeenCalled()
+    expect(router.currentRoute.value.name).toBe('List')
+  })
+
+  it('re-joins when stored meta has a different token (token rotated by owner)', async () => {
+    vi.mocked(sync.getMeta).mockReturnValue({ authToken: 'oldtoken', role: 'editor', lastCursor: 1 })
+    vi.mocked(sync.join).mockResolvedValue({ ok: true })
+    window.location.hash = '#join=listid123.newtoken'
+    const router = makeRouter()
+    await mountApp(router)
+    expect(sync.join).toHaveBeenCalledWith('listid123', 'newtoken')
     expect(router.currentRoute.value.name).toBe('List')
   })
 

--- a/tests/unit/sync/provision-join.spec.ts
+++ b/tests/unit/sync/provision-join.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { provision, join } from '@/sync'
 import { provisionList, joinList, upsertItem } from '@/sync/transport'
-import { startPoller } from '@/sync/poll'
+import { startPoller, stopPoller } from '@/sync/poll'
 import { applyJoinPayload } from '@/sync/reconcile'
 import { getMeta } from '@/sync/storage'
 import { _resetForTest as resetQueueForTest } from '@/sync/queue'
@@ -14,7 +14,7 @@ vi.mock('@/sync/transport', () => ({
   joinList: vi.fn(),
   upsertItem: vi.fn().mockResolvedValue({ ok: false, error: { kind: 'network' as const } })
 }))
-vi.mock('@/sync/poll', () => ({ startPoller: vi.fn() }))
+vi.mock('@/sync/poll', () => ({ startPoller: vi.fn(), stopPoller: vi.fn() }))
 vi.mock('@/sync/reconcile', () => ({ applyJoinPayload: vi.fn() }))
 
 const mProvisionList = vi.mocked(provisionList)
@@ -173,5 +173,18 @@ describe('sync/index — join', () => {
     expect(mApplyJoinPayload).toHaveBeenCalledWith(data)
     expect(getMeta('list2')).toEqual({ authToken: 'tok2', role: 'editor', lastCursor: 1700 })
     expect(mStartPoller).toHaveBeenCalledWith('list2')
+  })
+
+  it('stops any prior poller before joining so a stale-token 401 cannot wipe the list', async () => {
+    const data = { listId: 'list3', role: 'editor' as const, name: 'Rotated', version: 1, cursor: 0, items: [] }
+    mJoinList.mockResolvedValue({ ok: true, data })
+
+    await join('list3', 'fresh')
+
+    expect(vi.mocked(stopPoller)).toHaveBeenCalledWith('list3')
+    // Ordering: the stop must occur before the new poller is registered.
+    const stopOrder = vi.mocked(stopPoller).mock.invocationCallOrder[0]
+    const startOrder = mStartPoller.mock.invocationCallOrder[0]
+    expect(stopOrder).toBeLessThan(startOrder)
   })
 })


### PR DESCRIPTION
## Summary
- `handleJoinFragment` now compares the link's token to the stored `authToken`. On mismatch it falls through to the full join flow instead of short-circuiting on `getMeta` truthy.
- `sync.join` first stops any prior poller. The poller's stopped-state check then discards an in-flight, stale-token 401 so `cleanupListLocally` cannot fire after the new meta is already in place.
- Tests cover same-token short-circuit, rotated-token rejoin, and the stopPoller-before-startPoller ordering.

Closes #182

## Test plan
- [x] `npx vitest run` — all 240 tests pass.
- [x] `npx vue-tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)