### PR TITLE
fix(toast): render in top-layer dialog so modals can't bury them

### DIFF
--- a/src/components/ToastContainer.vue
+++ b/src/components/ToastContainer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="toast-container">
+  <dialog ref="dialogEl" class="toast-container" aria-label="Notifications">
     <div v-for="toast in toastStore.toasts"
          :key="toast.id"
          class="toast"
@@ -12,20 +12,42 @@
         <font-awesome-icon icon="times-circle"/>
       </button>
     </div>
-  </div>
+  </dialog>
 </template>
 
 <script setup lang="ts">
+import { ref, watch } from 'vue'
 import { useToastStore } from '@/stores/toast'
 
 const toastStore = useToastStore()
+const dialogEl = ref<HTMLDialogElement | null>(null)
+
+// A <dialog> opened with .show() is promoted to the browser's top layer,
+// which sits above any z-index — including ::backdrop and other dialogs.
+// Re-opening on every toast count change brings the toasts back to the top
+// of the top-layer stack so a later showModal() (ShareSheet, ConfirmModal)
+// cannot bury them.
+watch(() => toastStore.toasts.length, (n) => {
+  const dlg = dialogEl.value
+  if (!dlg) return
+  if (dlg.open) dlg.close()
+  if (n > 0) dlg.show()
+})
 </script>
 
 <style lang="scss">
 @reference "../assets/main.css";
 
 .toast-container {
-  @apply fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex flex-col gap-2 items-center pointer-events-none w-full max-w-sm px-4;
+  // Reset UA dialog chrome — we just want the top-layer promotion.
+  @apply m-0 border-0 bg-transparent p-0;
+  @apply fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex-col gap-2 items-center pointer-events-none w-full max-w-sm px-4;
+  // dialog defaults to display: none; only flex when open.
+  display: none;
+
+  &[open] {
+    @apply flex;
+  }
 }
 
 .toast {

--- a/tests/unit/components/ToastContainer.spec.ts
+++ b/tests/unit/components/ToastContainer.spec.ts
@@ -1,0 +1,82 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import ToastContainer from '@/components/ToastContainer.vue'
+import { useToastStore } from '@/stores/toast'
+
+describe('ToastContainer', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    // jsdom has no native <dialog>.show/close — emulate enough for assertions.
+    HTMLDialogElement.prototype.show = vi.fn(function (this: HTMLDialogElement) {
+      this.open = true
+    })
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+      this.open = false
+      this.dispatchEvent(new Event('close'))
+    })
+  })
+
+  it('renders a <dialog> as the toast container (top-layer promotion)', () => {
+    const wrapper = mount(ToastContainer, {
+      global: { stubs: { FontAwesomeIcon: { template: '<span/>' } } }
+    })
+    expect(wrapper.element.tagName).toBe('DIALOG')
+  })
+
+  it('opens the dialog with .show() (non-modal) when a toast is added', async () => {
+    const wrapper = mount(ToastContainer, {
+      attachTo: document.body,
+      global: { stubs: { FontAwesomeIcon: { template: '<span/>' } } }
+    })
+    const showSpy = HTMLDialogElement.prototype.show as ReturnType<typeof vi.fn>
+    expect(showSpy).not.toHaveBeenCalled()
+
+    useToastStore().add('hello', 'info')
+    await flushPromises()
+
+    expect(showSpy).toHaveBeenCalledTimes(1)
+    expect((wrapper.element as HTMLDialogElement).open).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('re-opens the dialog on each new toast so it stays on top of the top-layer stack', async () => {
+    const wrapper = mount(ToastContainer, {
+      attachTo: document.body,
+      global: { stubs: { FontAwesomeIcon: { template: '<span/>' } } }
+    })
+    const showSpy = HTMLDialogElement.prototype.show as ReturnType<typeof vi.fn>
+    const closeSpy = HTMLDialogElement.prototype.close as ReturnType<typeof vi.fn>
+
+    const store = useToastStore()
+    store.add('first', 'info')
+    await flushPromises()
+    store.add('second', 'error')
+    await flushPromises()
+
+    expect(showSpy).toHaveBeenCalledTimes(2)
+    // The second add closed then re-showed; first add only show()-ed.
+    expect(closeSpy).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
+
+  it('closes the dialog when the last toast is dismissed', async () => {
+    const wrapper = mount(ToastContainer, {
+      attachTo: document.body,
+      global: { stubs: { FontAwesomeIcon: { template: '<span/>' } } }
+    })
+    const closeSpy = HTMLDialogElement.prototype.close as ReturnType<typeof vi.fn>
+
+    const store = useToastStore()
+    store.add('hello', 'info')
+    await flushPromises()
+    closeSpy.mockClear()
+
+    store.dismiss(store.toasts[0].id)
+    await flushPromises()
+
+    expect(closeSpy).toHaveBeenCalled()
+    expect((wrapper.element as HTMLDialogElement).open).toBe(false)
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- ToastContainer now wraps its toasts in a `<dialog>` opened via `.show()` (non-modal). Native dialogs live in the browser top layer, so toasts now sit above any `showModal()`-promoted dialog instead of being hidden behind its `::backdrop`.
- Re-opens the dialog on every toast count change so a later modal can't bury earlier toasts in top-layer stack order.
- New tests cover the dialog element, `.show()` invocation, re-open on second toast, and close on last dismiss.

Closes #181

## Test plan
- [x] `npx vitest run` — 242/242 pass.
- [x] `npx vue-tsc --noEmit` — clean.
- [x] `npm run build` — production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)